### PR TITLE
Need to explicitly require AC::Responder for Rails 4.2+ & responders gem

### DIFF
--- a/lib/garage/app_responder.rb
+++ b/lib/garage/app_responder.rb
@@ -1,4 +1,5 @@
 require 'action_controller'
+require 'action_controller/responder'
 require "garage/hypermedia_responder"
 require "garage/resource_casting_responder"
 require "garage/paginating_responder"


### PR DESCRIPTION
Since AC::responder has been moved to [responders gem](https://github.com/plataformatec/responders) in [this commit](https://github.com/rails/rails/commit/ee77770d57de9da87b05a2fe84b9d46ec6852c62), current garage implementation would no more work with Rails 4.2+.

Firstly, on Rails 4.2 & responders gem, you need to explicitly require 'ac/responder' because `:Responders` would no more be autoloaded. I simply added a require call in the attached patch because requiring the responder here wouldn't do any harm regardless of Rails version.

Another thing we're missing is a dependency. I wish we could do something like "hey, please lemme add_dependency to 'responders' only if Rails version is >= 4.2", but unfortunately AFAIK rubygems is not that clever.
The responders gem claims that it supports Rails 3.2+, so we probably could just add that gem to the dependency, but I don't like depending on something that we don't actually use.
Maybe we could add some documentation for 4.2 users at the moment?
