### PR TITLE
Add DEFAULT_MAX_PER_PAGE into Garage::PaginatingResponder

### DIFF
--- a/lib/garage/paginating_responder.rb
+++ b/lib/garage/paginating_responder.rb
@@ -1,5 +1,7 @@
 module Garage
   module PaginatingResponder
+    DEFAULT_MAX_PER_PAGE = 100
+
     def display(resource, *args)
       if @options[:paginate]
         resource = paginate resource
@@ -30,7 +32,7 @@ module Garage
     end
 
     def max_per_page
-      @options[:max_per_page] || @max_per_page || 100
+      @options[:max_per_page] || @max_per_page || DEFAULT_MAX_PER_PAGE
     end
 
     def set_total_count(rs, per_page)


### PR DESCRIPTION
For now it is difficult to stub default max_per_page in spec and it causes us to create over 100 elements to verify inexitence of issue around max_per_page options.
So I add a constant to indicate default max_per_page value to make easy stubbing.
