### PR TITLE
Bump version of doorkeeper to 1.4.1

### DIFF
--- a/garage.gemspec
+++ b/garage.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", '>= 4.0.0'
-  s.add_dependency "doorkeeper", ">= 0.6.7", "< 1.4.0"
+  s.add_dependency "doorkeeper", ">= 0.6.7", "< 1.5.0"
   s.add_dependency "rack-accept-default", "~> 0.0.2"
   s.add_dependency "oj"
   s.add_dependency "responders"


### PR DESCRIPTION
For the security update.

https://github.com/doorkeeper-gem/doorkeeper/blob/master/CHANGELOG.md#141
