### PR TITLE
Accept doorkeeper > 2.2.0

### DIFF
--- a/garage.gemspec
+++ b/garage.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", '>= 4.0.0'
-  s.add_dependency "doorkeeper", ">= 2.0.0", "< 2.2.0"
+  s.add_dependency "doorkeeper", ">= 2.0.0"
   s.add_dependency "rack-accept-default", "~> 0.0.2"
   s.add_dependency "oj"
   s.add_dependency "responders"

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -57,7 +57,7 @@ describe "Authorization" do
 
     context "with another valid scope" do
       let(:scopes) do
-        "sudo"
+        "public sudo"
       end
       it { should == 200 }
     end
@@ -146,7 +146,7 @@ describe "Authorization" do
 
   describe "GET /posts/namespaced" do
     let(:scopes) do
-      "foobar.read_post"
+      "public foobar.read_post"
     end
 
     context "with valid condition" do


### PR DESCRIPTION
Doorkeeper v2.0 aimed to require default scopes by default, but it did
not by mistake (doorkeeper-gem/doorkeeper#632). By doorkeeper v2.2.0,
the bug was fixed.

Garage's tests were passed by that bug, but since Doorkeeper v2.2.0,
Doorkeeper requires default scopes properly, so we have to add default
scopes in our tests.