### PR TITLE
Refactoring `Garage::OptionalResponseBodyResponder` into simpler code

### DIFF
--- a/lib/garage/optional_response_body_responder.rb
+++ b/lib/garage/optional_response_body_responder.rb
@@ -1,27 +1,14 @@
 module Garage::OptionalResponseBodyResponder
   protected
 
-  if Rails::VERSION::MAJOR > 4 ||
-      (Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR >= 2)
-    def api_behavior
-      api_behavior_handler || super
-    end
-  else
-    def api_behavior(error)
-      api_behavior_handler || super
-    end
-  end
-
-  private
-
-  def api_behavior_handler
+  def api_behavior(*)
     case
     when put? && options[:put] && options[:put][:body]
       display resource, status: options[:put][:status] || :ok
     when delete? && options[:delete] && options[:delete][:body]
       display resource, status: options[:delete][:status] || :ok
     else
-      nil
+      super
     end
   end
 end


### PR DESCRIPTION
This basically reverts 61012955f96141f4a3e4c53e64fdeee4cc0c7c42 and fa782dd76e1244c577846b9e3ee9691458f74ce1,
then changes the original `api_behavior` method to work regardless of Rails version.