### PR TITLE
Require "garage/version"

### DIFF
--- a/lib/garage.rb
+++ b/lib/garage.rb
@@ -1,6 +1,7 @@
 require "rails"
 require "rack-accept-default"
 
+require "garage/version"
 require "garage/strategy"
 require "garage/config"
 require "garage/nested_field_query"


### PR DESCRIPTION
To fix an issue with undefined constant on the current HEAD of master as below: 

```
/cache/bundle-install/ruby/2.2.0/bundler/gems/garage-240cb33053ba/lib/garage/strategy/auth_server.rb:30:in `<class:AccessTokenFetcher>': uninitialized constant Garage::VERSION (NameError)
	from /cache/bundle-install/ruby/2.2.0/bundler/gems/garage-240cb33053ba/lib/garage/strategy/auth_server.rb:27:in `<module:AuthServer>'
	from /cache/bundle-install/ruby/2.2.0/bundler/gems/garage-240cb33053ba/lib/garage/strategy/auth_server.rb:7:in `<module:Strategy>'
	from /cache/bundle-install/ruby/2.2.0/bundler/gems/garage-240cb33053ba/lib/garage/strategy/auth_server.rb:6:in `<module:Garage>'
	from /cache/bundle-install/ruby/2.2.0/bundler/gems/garage-240cb33053ba/lib/garage/strategy/auth_server.rb:5:in `<top (required)>'
	from /cache/bundle-install/ruby/2.2.0/bundler/gems/garage-240cb33053ba/lib/garage/strategy.rb:2:in `require'
	from /cache/bundle-install/ruby/2.2.0/bundler/gems/garage-240cb33053ba/lib/garage/strategy.rb:2:in `<top (required)>'
	from /cache/bundle-install/ruby/2.2.0/bundler/gems/garage-240cb33053ba/lib/garage.rb:4:in `require'
	from /cache/bundle-install/ruby/2.2.0/bundler/gems/garage-240cb33053ba/lib/garage.rb:4:in `<top (required)>'
	from /home/ubuntu/.rvm/gems/ruby-2.2.2@global/gems/bundler-1.9.4/lib/bundler/runtime.rb:76:in `require'
	from /home/ubuntu/.rvm/gems/ruby-2.2.2@global/gems/bundler-1.9.4/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
	from /home/ubuntu/.rvm/gems/ruby-2.2.2@global/gems/bundler-1.9.4/lib/bundler/runtime.rb:72:in `each'
	from /home/ubuntu/.rvm/gems/ruby-2.2.2@global/gems/bundler-1.9.4/lib/bundler/runtime.rb:72:in `block in require'
	from /home/ubuntu/.rvm/gems/ruby-2.2.2@global/gems/bundler-1.9.4/lib/bundler/runtime.rb:61:in `each'
	from /home/ubuntu/.rvm/gems/ruby-2.2.2@global/gems/bundler-1.9.4/lib/bundler/runtime.rb:61:in `require'
	from /home/ubuntu/.rvm/gems/ruby-2.2.2@global/gems/bundler-1.9.4/lib/bundler.rb:134:in `require'
	from /pipeline/build/config/application.rb:16:in `<top (required)>'
	from /pipeline/build/config/environment.rb:2:in `require'
	from /pipeline/build/config/environment.rb:2:in `<top (required)>'
	from /pipeline/build/spec/rails_helper.rb:4:in `require'
	from /pipeline/build/spec/rails_helper.rb:4:in `<top (required)>'
	from /pipeline/build/spec/models/channel_spec.rb:15:in `require'
	from /pipeline/build/spec/models/channel_spec.rb:15:in `<top (required)>'
	from /cache/bundle-install/ruby/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1226:in `load'
	from /cache/bundle-install/ruby/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1226:in `block in load_spec_files'
	from /cache/bundle-install/ruby/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1224:in `each'
	from /cache/bundle-install/ruby/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1224:in `load_spec_files'
	from /cache/bundle-install/ruby/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:97:in `setup'
	from /cache/bundle-install/ruby/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:85:in `run'
	from /cache/bundle-install/ruby/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:70:in `run'
	from /cache/bundle-install/ruby/2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:38:in `invoke'
	from /cache/bundle-install/ruby/2.2.0/gems/rspec-core-3.2.3/exe/rspec:4:in `<top (required)>'
	from /cache/bundle-install/ruby/2.2.0/bin/rspec:23:in `load'
	from /cache/bundle-install/ruby/2.2.0/bin/rspec:23:in `<main>'
```