### PR TITLE
Bump version of http_accept_language to 2.0.0

### DIFF
--- a/app/controllers/garage/docs/resources_controller.rb
+++ b/app/controllers/garage/docs/resources_controller.rb
@@ -2,6 +2,8 @@ require 'oauth2'
 require 'http_accept_language'
 
 class Garage::Docs::ResourcesController < Garage::ApplicationController
+  include HttpAcceptLanguage::EasyAccess
+
   layout 'garage/application'
 
   before_filter :require_authentication
@@ -73,7 +75,7 @@ class Garage::Docs::ResourcesController < Garage::ApplicationController
   end
 
   def set_locale
-    @locale = params[:lang] || cookies[:garage_locale] || request.preferred_language_from(%w[en ja])
+    @locale = params[:lang] || cookies[:garage_locale] || http_accept_language.preferred_language_from(%w[en ja])
     cookies[:garage_locale] = @locale
   end
 

--- a/app/controllers/garage/docs/resources_controller.rb
+++ b/app/controllers/garage/docs/resources_controller.rb
@@ -1,9 +1,6 @@
 require 'oauth2'
-require 'http_accept_language'
 
 class Garage::Docs::ResourcesController < Garage::ApplicationController
-  include HttpAcceptLanguage::EasyAccess
-
   layout 'garage/application'
 
   before_filter :require_authentication

--- a/garage.gemspec
+++ b/garage.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "hashie"
   s.add_dependency "sass-rails"
   s.add_dependency "coffee-rails"
-  s.add_dependency "http_accept_language", "~> 1.0.2"
+  s.add_dependency "http_accept_language", "~> 2.0.0"
 
   s.add_development_dependency "appraisal"
 end

--- a/garage.gemspec
+++ b/garage.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "hashie"
   s.add_dependency "sass-rails"
   s.add_dependency "coffee-rails"
-  s.add_dependency "http_accept_language", "~> 2.0.0"
+  s.add_dependency "http_accept_language", ">= 2.0.0"
 
   s.add_development_dependency "appraisal"
 end

--- a/lib/garage.rb
+++ b/lib/garage.rb
@@ -1,5 +1,6 @@
 require "rails"
 require "rack-accept-default"
+require "http_accept_language"
 
 require "garage/version"
 require "garage/strategy"


### PR DESCRIPTION
`http_accept_language` was upgraded to 2.0.0 about 2 years ago, but Garage still depends on 1.0.x.
As there seems no reason to keep, I bump it to 2.0.0.