### PR TITLE
Support doorkeeper 3.0.0

### DIFF
--- a/lib/garage/controller_helper.rb
+++ b/lib/garage/controller_helper.rb
@@ -34,7 +34,7 @@ module Garage
     # Use this method to render 'unauthorized'.
     # Garage user may overwrite this method to response custom unauthorized response.
     # @return [Hash]
-    def unauthorized_render_options
+    def unauthorized_render_options(error: nil)
       { json: { status_code: 401, error: "Unauthorized (invalid token)" } }
     end
 


### PR DESCRIPTION
Related to https://github.com/cookpad/garage-doorkeeper/issues/1.

doorkeeper 3.0.0 later,
`doorkeeper_unauthorized_render_options` method began to have `error` argument. 

follow doorkeeper of change.