### PR TITLE
Add `Garage.configure {}` to Advanced Configurations of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ end
 In `config/initializer/garage.rb`:
 
 ```ruby
+Garage.configure {}
+
 # Optional
 Garage::TokenScope.configure do
   register :public, desc: "accessing publicly available data" do


### PR DESCRIPTION
If it has been missing, garage raises error like `undefined method `strategy=' for nil:NilClass`