### PR TITLE
Fix issue with STI models

### DIFF
--- a/lib/garage/representer.rb
+++ b/lib/garage/representer.rb
@@ -75,6 +75,7 @@ module Garage::Representer
     attr_writer :representer_attrs
 
     def inherited(child)
+      super
       child.representer_attrs = self.representer_attrs.clone
     end
 


### PR DESCRIPTION
When I try to implement model with single table inheritance with garage, there's a issue like below

example code:

```ruby
class User < ActiveRecord::Base
  include Garage::Representer
  include Garage::Authorizable
end

class Admin < User
end
```

and when I create new `Admin` model 

The error occurs like 

```
NoMethodError: undefined method `[]' for nil:NilClass
```

this is because [garage overrides `.inherited` method](https://github.com/cookpad/garage/blob/master/lib/garage/representer.rb#L77-L79)

so I added `super` to `.inherited` 