### PR TITLE
Remove unnecessary `preserve` helper

### DIFF
--- a/app/views/garage/docs/resources/show.html.haml
+++ b/app/views/garage/docs/resources/show.html.haml
@@ -13,4 +13,4 @@
     = @document.toc
 
   .section.document
-    = preserve @document.render
+    = @document.render


### PR DESCRIPTION
`preserve` makes sense only in whitespace-sensitive tags.