### PR TITLE
Fix deprecation warnings in db:migrate

### DIFF
--- a/spec/dummy/db/migrate/20130501215002_create_doorkeeper_tables.rb
+++ b/spec/dummy/db/migrate/20130501215002_create_doorkeeper_tables.rb
@@ -5,7 +5,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       t.string  :uid,          :null => false
       t.string  :secret,       :null => false
       t.string  :redirect_uri, :null => false
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :oauth_applications, :uid, :unique => true

--- a/spec/dummy/db/migrate/20130501215033_create_users.rb
+++ b/spec/dummy/db/migrate/20130501215033_create_users.rb
@@ -4,7 +4,7 @@ class CreateUsers < ActiveRecord::Migration
       t.string :name
       t.string :email
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/spec/dummy/db/migrate/20130501215056_create_posts.rb
+++ b/spec/dummy/db/migrate/20130501215056_create_posts.rb
@@ -5,7 +5,7 @@ class CreatePosts < ActiveRecord::Migration
       t.string :title
       t.string :body
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/spec/dummy/db/migrate/20130508032709_create_comments.rb
+++ b/spec/dummy/db/migrate/20130508032709_create_comments.rb
@@ -5,7 +5,7 @@ class CreateComments < ActiveRecord::Migration
       t.integer :post_id
       t.string :body
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -17,8 +17,8 @@ ActiveRecord::Schema.define(version: 20141209001746) do
     t.integer  "user_id",    limit: 4
     t.integer  "post_id",    limit: 4
     t.string   "body",       limit: 255
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|
@@ -54,8 +54,8 @@ ActiveRecord::Schema.define(version: 20141209001746) do
     t.string   "uid",          limit: 255,              null: false
     t.string   "secret",       limit: 255,              null: false
     t.string   "redirect_uri", limit: 255,              null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.string   "scopes",       limit: 255, default: "", null: false
   end
 
@@ -65,15 +65,15 @@ ActiveRecord::Schema.define(version: 20141209001746) do
     t.integer  "user_id",    limit: 4
     t.string   "title",      limit: 255
     t.string   "body",       limit: 255
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   create_table "users", force: :cascade do |t|
     t.string   "name",       limit: 255
     t.string   "email",      limit: 255
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
 end


### PR DESCRIPTION
DEPRECATION WARNING: `#timestamps` was called without specifying an
option for `null`. In Rails 5, this behavior will change to
`null: false`. You should manually specify `null: true` to prevent the
behavior of your existing migrations from changing.