### PR TITLE
Simplify primitive? check

### DIFF
--- a/lib/garage/representer.rb
+++ b/lib/garage/representer.rb
@@ -159,14 +159,14 @@ module Garage::Representer
     def encode_value(value, responder, selector)
       if !value.nil? && value.respond_to?(:represent!)
         responder.encode_to_hash(value, partial: true, selector: selector)
-      elsif primitive?(value.class)
+      elsif primitive?(value)
         value
       else
         raise NonEncodableValue, "#{value.class} can not be encoded directly. Forgot to include Garage::Representer?"
       end
     end
 
-    def primitive?(klass)
+    def primitive?(value)
       [
         ActiveSupport::TimeWithZone,
         Date,
@@ -181,7 +181,7 @@ module Garage::Representer
         TrueClass,
         FalseClass,
         Symbol,
-      ].any? {|k| klass.ancestors.include?(k) }
+      ].any? {|k| value.is_a?(k) }
     end
 
     private


### PR DESCRIPTION
`Object#is_a?` is simpler and more efficient than checking
`Module#ancestors` .

It introduces incompatibility since `primitive?` now takes an object instead of class.
If `primitive?` should keep compatibility, `klass <= k` might be an alternative.