### PR TITLE
Fix typo `initializer` -> `initializers` of a README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ end
 
 ## Advanced Configurations
 
-In `config/initializer/garage.rb`:
+In `config/initializers/garage.rb`:
 
 ```ruby
 Garage.configure {}


### PR DESCRIPTION
`config/initializer` directory is undefined in the Rails.