### PR TITLE
use `xxx_action` instead of deprecated `xxx_filter`

### DIFF
--- a/app/controllers/garage/docs/resources_controller.rb
+++ b/app/controllers/garage/docs/resources_controller.rb
@@ -3,11 +3,11 @@ require 'oauth2'
 class Garage::Docs::ResourcesController < Garage::ApplicationController
   layout 'garage/application'
 
-  before_filter :require_authentication
-  before_filter :require_docs_application
-  before_filter :require_console_application
-  before_filter :set_locale
-  before_filter :require_document, only: :show
+  before_action :require_authentication
+  before_action :require_docs_application
+  before_action :require_console_application
+  before_action :set_locale
+  before_action :require_document, only: :show
 
   def index
     @documents = Garage::Docs::Document.all

--- a/doc/restful_actions.md
+++ b/doc/restful_actions.md
@@ -91,7 +91,7 @@ This declares that the access token should have scope(s) to access `PrivatePost`
 You can also *add* extra access scope or permission in addition to `@resource(s)` in your controller.
 
 ```ruby
-before_filter require_recipe
+before_action require_recipe
 def require_recipe
   @recipe = Recipe.find(params[:recipe_id])
   require_permission! @recipe, :read

--- a/lib/garage/controller_helper.rb
+++ b/lib/garage/controller_helper.rb
@@ -6,7 +6,7 @@ module Garage
     included do
       use Rack::AcceptDefault
 
-      around_filter :notify_request_stats
+      around_action :notify_request_stats
 
       include Garage.configuration.strategy
 
@@ -16,7 +16,7 @@ module Garage
         end
       end
 
-      before_filter Garage::HypermediaFilter
+      before_action Garage::HypermediaFilter
 
       respond_to :json # , :msgpack
       self.responder = Garage::AppResponder

--- a/lib/garage/restful_actions.rb
+++ b/lib/garage/restful_actions.rb
@@ -21,9 +21,9 @@ module Garage
     extend ActiveSupport::Concern
 
     included do
-      before_filter :require_resource, :only => [:show, :update, :destroy]
-      before_filter :require_resources, :only => [:index, :create]
-      before_filter :require_action_permission_crud, :only => [:index, :create, :show, :update, :destroy], :if => -> (_) { verify_permission? }
+      before_action :require_resource, :only => [:show, :update, :destroy]
+      before_action :require_resources, :only => [:index, :create]
+      before_action :require_action_permission_crud, :only => [:index, :create, :show, :update, :destroy], :if => -> (_) { verify_permission? }
     end
 
     module ClassMethods
@@ -92,7 +92,7 @@ module Garage
     #
     # Examples
     #
-    #   before_filter :require_recipe
+    #   before_action :require_recipe
     #   def require_recipe
     #     @recipe = Recipe.find(params[:recipe_id])
     #     require_permission! @recipe, :read
@@ -110,7 +110,7 @@ module Garage
     #
     # Examples
     #
-    #   before_filter :require_stream
+    #   before_action :require_stream
     #   def require_stream
     #     require_access! PostStream, :read
     #   end

--- a/spec/dummy/app/controllers/posts_controller.rb
+++ b/spec/dummy/app/controllers/posts_controller.rb
@@ -1,11 +1,11 @@
 class PostsController < ApiController
   include Garage::RestfulActions
 
-  before_filter :require_user, only: :private
-  before_filter :require_private_resource, only: :private
-  before_filter :require_namespaced_resource, only: :namespaced
-  before_filter :require_index_resource, only: [:hide, :capped]
-  before_filter :require_action_permission, only: [:private, :hide, :capped, :namespaced]
+  before_action :require_user, only: :private
+  before_action :require_private_resource, only: :private
+  before_action :require_namespaced_resource, only: :namespaced
+  before_action :require_index_resource, only: [:hide, :capped]
+  before_action :require_action_permission, only: [:private, :hide, :capped, :namespaced]
 
   def private
     respond_with @resources


### PR DESCRIPTION
This removes the warning of Rails such as the following.

```
DEPRECATION WARNING: around_filter is deprecated and will be removed in Rails 5.1. Use around_action instead. (called from block in <module:ControllerHelper> at garage-16560c5a5afc/lib/garage/controller_helper.rb:9)
```