### PR TITLE
Check if resource includes Enumerable module

### DIFF
--- a/lib/garage/config.rb
+++ b/lib/garage/config.rb
@@ -37,7 +37,7 @@ module Garage
 
     def cast_resource
       @cast_resource ||= proc { |resource|
-        if resource.respond_to?(:map)
+        if resource.is_a?(Enumerable)
           resource.map(&:to_resource)
         else
           resource.to_resource


### PR DESCRIPTION
I propose to use `is_a?(Enumerable)` instead of `respond_to?(:map)` when casting resources. 

The current implementation breaks if `resource` happens to have `map` method, but is not a collection. Checking it includes `Enumerable` module should suffice for the purpose, and this will work even if it has `map` method.

