### PR TITLE
Better checking to detect resource(s) is a collection

### DIFF
--- a/lib/garage/config.rb
+++ b/lib/garage/config.rb
@@ -37,7 +37,7 @@ module Garage
 
     def cast_resource
       @cast_resource ||= proc { |resource|
-        if resource.respond_to?(:map)
+        if resource.respond_to?(:map) && resource.respond_to?(:to_a)
           resource.map(&:to_resource)
         else
           resource.to_resource

--- a/lib/garage/hypermedia_responder.rb
+++ b/lib/garage/hypermedia_responder.rb
@@ -12,7 +12,7 @@ module Garage
     end
 
     def transform(resources)
-      if resources.respond_to?(:map)
+      if resources.respond_to?(:map) && resources.respond_to?(:to_a)
         resources.map {|resource| encode_to_hash(resource, partial: true) }
       else
         encode_to_hash(resources)

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -23,6 +23,10 @@ class Post < ActiveRecord::Base
     user
   end
 
+  def map
+    'Tokyo'
+  end
+
   def build_permissions(perms, other)
     perms.permits! :read
     perms.permits! :write if owner == other


### PR DESCRIPTION
Based on discussion in https://github.com/cookpad/garage/pull/47, I've added `resource.respond_to?(:to_a)` on top of check of `resource.respond_to?(:map)` in `HypermediaResponder` and `ResourceCastingResponder` .

This'll work around an issue with a model class with `#map` method that doesn't behave like in a collection or `Enumerable`.