### PR TITLE
Improve AuthServer strategy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ end
 
 group :test do
   gem "webmock"
+  gem "timecop"
 end
 
 # Declare your gem's dependencies in garage.gemspec.

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -26,6 +26,7 @@ end
 
 group :test do
   gem "webmock"
+  gem "timecop"
 end
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -26,6 +26,7 @@ end
 
 group :test do
   gem "webmock"
+  gem "timecop"
 end
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -26,6 +26,7 @@ end
 
 group :test do
   gem "webmock"
+  gem "timecop"
 end
 
 gemspec :path => "../"

--- a/lib/garage/config.rb
+++ b/lib/garage/config.rb
@@ -12,8 +12,13 @@ module Garage
   class Config
     DEFAULT_RESCUE_ERROR = true
 
-    attr_writer :cast_resource, :docs, :rescue_error, :strategy
-    attr_accessor :auth_server_url, :auth_server_host, :auth_server_timeout
+    attr_writer :cast_resource, :docs, :rescue_error, :strategy, :cache_acceess_token_validation
+    attr_accessor :auth_server_url, :auth_server_host, :auth_server_timeout, :ttl_for_access_token_cache
+
+    def initialize
+      @cache_acceess_token_validation = false
+      @ttl_for_access_token_cache = 5.minutes
+    end
 
     # Set false if you want to rescue errors by yourself
     # @return [true, false] A flag to rescue Garage::HTTPError in ControllerHelper (default: true)
@@ -43,6 +48,10 @@ module Garage
           resource.to_resource
         end
       }
+    end
+
+    def cache_acceess_token_validation?
+      !!@cache_acceess_token_validation
     end
 
     class Builder

--- a/lib/garage/exceptions.rb
+++ b/lib/garage/exceptions.rb
@@ -29,4 +29,21 @@ module Garage
 
   class PermissionError < Unauthorized; end
   class MissingScopeError < Unauthorized; end
+
+  class AuthBackendTimeout < HTTPError
+    def initialize(open_timeout, read_timeout)
+      @status = :internal_server_error
+      super("Auth backend timed out: open_timeout=#{open_timeout}, read_timeout=#{read_timeout}")
+    end
+  end
+
+  class AuthBackendError < HTTPError
+    attr_reader :response
+
+    def initialize(response)
+      @status = :internal_server_error
+      @response = response
+      super("Auth backend responded error: status=#{response.status_code}")
+    end
+  end
 end

--- a/lib/garage/strategy/access_token.rb
+++ b/lib/garage/strategy/access_token.rb
@@ -18,13 +18,13 @@ module Garage
       end
 
       def expired_at
-        @expired_at ? DateTime.parse(@expired_at) : nil
+        @expired_at.present? ? Time.zone.parse(@expired_at) : nil
       rescue ArgumentError, TypeError
         nil
       end
 
       def revoked_at
-        @revoked_at ? DateTime.parse(@revoked_at) : nil
+        @revoked_at.present? ? Time.zone.parse(@revoked_at) : nil
       rescue ArgumentError, TypeError
         nil
       end

--- a/spec/garage/strategy/access_token_spec.rb
+++ b/spec/garage/strategy/access_token_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe Garage::Strategy::AccessToken do
+  describe '#expired?' do
+    before { Timecop.freeze(Time.zone.parse('2015/01/01 00:00:00')) }
+    subject { Garage::Strategy::AccessToken.new(attrs).expired? }
+    let(:attrs) { { expired_at: expired_at, revoked_at: nil } }
+
+    context 'when expired_at is null' do
+      let(:expired_at) { nil }
+      it { should be_false }
+    end
+
+    context 'when expired_at is empty string' do
+      let(:expired_at) { '' }
+      it { should be_false }
+    end
+
+    context 'when expired_at is invalid value' do
+      let(:expired_at) { 'xxx' }
+      it { should be_false }
+    end
+
+    context 'when expired_at is future' do
+      let(:expired_at) { Time.zone.parse('2015/02/01 00:00:00').to_s }
+      it { should be_false }
+    end
+
+    context 'when expired_at is past' do
+      let(:expired_at) { Time.zone.parse('2014/12/01 00:00:00').to_s }
+      it { should be_true }
+    end
+  end
+end

--- a/spec/garage/strategy/auth_server_spec.rb
+++ b/spec/garage/strategy/auth_server_spec.rb
@@ -6,55 +6,151 @@ RSpec.describe Garage::Strategy::AuthServer do
   end
 
   let(:auth_server_url) { 'http://example.com/token' }
+  let(:request) { double(:request, authorization: authorization, params: {}, headers: {}) }
+  let(:authorization) { "Bearer #{requested_token}" }
+  let(:requested_token) { 'dummy_token' }
+  let(:response) do
+    {
+      token: requested_token,
+      token_type: 'bearer',
+      scope: 'public read_user',
+      application_id: 1,
+      resource_owner_id: 1,
+      expired_at: 1.minute.since,
+      revoked_at: nil,
+    }
+  end
 
-  describe 'AccessTokenFetcher.fetch' do
+  describe Garage::Strategy::AuthServer::AccessTokenFetcher do
     let(:fetcher) { Garage::Strategy::AuthServer::AccessTokenFetcher }
-    let(:request) { double(:request, authorization: requested_token) }
-    let(:requested_token) { 'dummy_token' }
 
-    context 'when authorization succeed' do
-      let(:response_json) { response.to_json }
-      let(:response) do
-        {
-          token: requested_token,
-          token_type: 'bearer',
-          scope: 'public read_user',
-          application_id: 1,
-          resource_owner_id: 1,
-          expired_at: 1.minute.since,
-          revoked_at: nil,
-        }
+    describe '.fetch' do
+      context 'when authorization succeed' do
+        before do
+          stub_request(:get, auth_server_url).to_return(status: 200, body: response.to_json)
+        end
+
+        it 'returns valid access token' do
+          token = fetcher.fetch(request)
+          expect(token).to be_accessible
+        end
       end
 
-      before do
-        stub_request(:get, auth_server_url).to_return(status: 200, body: response_json)
+      context 'when authorization failed' do
+        let(:response) { {} }
+
+        before do
+          stub_request(:get, auth_server_url).to_return(status: 401, body: response.to_json)
+        end
+
+        it 'returns nil' do
+          token = fetcher.fetch(request)
+          expect(token).to be_nil
+        end
       end
 
-      it 'returns valid access token' do
-        token = fetcher.fetch(request)
-        expect(token).to be_accessible
+      context 'when auth server responds an error' do
+        before do
+          stub_request(:get, auth_server_url).to_return(status: 500, body: { error: 'unexpected_error' }.to_json)
+        end
+
+        it 'raises Garage::AuthBackendError' do
+          expect { fetcher.fetch(request) }.to raise_error(Garage::AuthBackendError)
+        end
+      end
+
+      context 'when the request to auth server timed out' do
+        before do
+          stub_request(:get, auth_server_url).to_timeout
+        end
+
+        it 'raises Garage::AuthBackendTimeout' do
+          expect { fetcher.fetch(request) }.to raise_error(Garage::AuthBackendTimeout)
+        end
+      end
+
+      context 'when requested token is empty' do
+        let(:authorization) { nil }
+
+        it 'does not request to auth server then returns nil' do
+          token = fetcher.fetch(request)
+          expect(token).to be_nil
+        end
       end
     end
 
-    context 'when authorization failed' do
-      let(:response_json) { {}.to_json }
+    describe '.fetch with caching' do
+      let(:cache_key) { "garage_gem/token_cache/#{Garage::VERSION}/#{requested_token}" }
 
       before do
-        stub_request(:get, auth_server_url).to_return(status: 401, body: response_json)
+        allow(Garage.configuration).to receive(:cache_acceess_token_validation?).and_return(true)
+        Rails.cache.clear
+      end
+      after { Rails.cache.clear }
+
+      context 'with bearer token on authorization header' do
+        context 'when cache hits' do
+          let(:access_token) { double(:access_token, expired?: false) }
+
+          it 'reads cache then return cache' do
+            expect(Rails.cache).to receive(:read).
+              with(cache_key).
+              and_return(access_token)
+            expect(fetcher.fetch(request)).to eq(access_token)
+          end
+        end
+
+        context 'when cache does not hit' do
+          it 'reads cache then requests access_token then writes to cache' do
+            expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+            stub = stub_request(:get, auth_server_url).
+              to_return(body: response.to_json, status: 200)
+            expect(Rails.cache).to receive(:write)
+
+            expect(fetcher.fetch(request)).to be_accessible
+            expect(stub).to have_been_requested
+          end
+        end
+
+        context 'when cache does not hit and authz fails' do
+          it 'does not write to cache and returns nil' do
+            expect(Rails.cache).to receive(:read).with(cache_key).and_return(nil)
+            stub = stub_request(:get, auth_server_url).
+              to_return(body: {}.to_json, status: 401)
+            expect(Rails.cache).not_to receive(:write)
+
+            expect(fetcher.fetch(request)).to be_nil
+            expect(stub).to have_been_requested
+          end
+        end
       end
 
-      it 'returns nil' do
-        token = fetcher.fetch(request)
-        expect(token).to be_nil
+      context 'with access token on request parameter' do
+        let(:request) { double(:request, authorization: nil, params: params, headers: {}) }
+        let(:params) { { access_token: requested_token } }
+
+        it 'does not read cache and requests access token' do
+          expect(Rails.cache).not_to receive(:read)
+          stub = stub_request(:get, auth_server_url + "?access_token=#{requested_token}").
+            to_return(body: response.to_json, status: 200)
+
+          expect(fetcher.fetch(request)).to be_accessible
+          expect(stub).to have_been_requested
+        end
       end
-    end
 
-    context 'when requested token is empty' do
-      let(:requested_token) { nil }
+      context 'with basic authentication' do
+        let(:secrets) { 'xxx:yyy' }
+        let(:authorization) { "Basic #{Base64.strict_encode64(secrets)}" }
+        let(:url) { auth_server_url.gsub(%r{\A(http://)(.*)\z}) { "#{$1}#{secrets}@#{$2}" } }
 
-      it 'does not request to auth server then returns nil' do
-        token = fetcher.fetch(request)
-        expect(token).to be_nil
+        it 'does not read cache and requests access token' do
+          expect(Rails.cache).not_to receive(:read)
+          stub = stub_request(:get, url).to_return(body: response.to_json, status: 200)
+
+          expect(fetcher.fetch(request)).to be_accessible
+          expect(stub).to have_been_requested
+        end
       end
     end
   end


### PR DESCRIPTION
- Raise error when auth server has timed out or responded errors (and rescue and render 500 error).
- Caching access token validation feature (default off).
- Pass through some header values to auth server.
- Accept access tokens with query parameter for backward-compatibility.