### PR TITLE
Treat as valid access token with null token value

### DIFF
--- a/lib/garage/strategy/access_token.rb
+++ b/lib/garage/strategy/access_token.rb
@@ -38,11 +38,7 @@ module Garage
       end
 
       def accessible?
-        valid? && !revoked? && !expired?
-      end
-
-      def valid?
-        token.present? && token_type.present?
+        !expired? && !revoked?
       end
 
       def revoked?

--- a/lib/garage/strategy/test.rb
+++ b/lib/garage/strategy/test.rb
@@ -12,7 +12,7 @@ module Garage
           @access_token
         else
           token = AccessToken.new(attributes.merge(token: requested_token, token_type: 'bearer'))
-          @access_token = token.valid? ? token : nil
+          @access_token = token.token.present? && token.accessible? ? token : nil
         end
       end
 

--- a/spec/garage/strategy/access_token_spec.rb
+++ b/spec/garage/strategy/access_token_spec.rb
@@ -1,10 +1,26 @@
 require 'spec_helper'
 
 RSpec.describe Garage::Strategy::AccessToken do
+  let(:attrs) { { expired_at: expired_at, token: token, revoked_at: nil } }
+  let(:token) { 'xxx' }
+  let(:expired_at) { nil }
+
+  describe '#accessible?' do
+    subject { Garage::Strategy::AccessToken.new(attrs).accessible? }
+
+    context 'when valid case' do
+      it { should be_true }
+    end
+
+    context 'when token is null' do
+      let(:token) { nil }
+      it { should be_true }
+    end
+  end
+
   describe '#expired?' do
     before { Timecop.freeze(Time.zone.parse('2015/01/01 00:00:00')) }
     subject { Garage::Strategy::AccessToken.new(attrs).expired? }
-    let(:attrs) { { expired_at: expired_at, revoked_at: nil } }
 
     context 'when expired_at is null' do
       let(:expired_at) { nil }


### PR DESCRIPTION
Some authorization flow, auth server responds `token` value as null.