### PR TITLE
Apply new gem name: the_garage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Garage supports OAuth 2 authorizations via Doorkeeper (more extensions to come),
 In `Gemfile`:
 
 ```ruby
-gem 'garage', github: 'cookpad/garage'
+# Notice this gem has "the_" prefix for gem name.
+gem 'the_garage'
 ```
 
 In your Rails model class:

--- a/garage.gemspec
+++ b/garage.gemspec
@@ -5,7 +5,7 @@ require "garage/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  s.name        = "garage"
+  s.name        = "the_garage"
   s.version     = Garage::VERSION
   s.authors     = ["Tatsuhiko Miyagawa"]
   s.email       = ["miyagawa@bulknews.net"]


### PR DESCRIPTION
Another "garage" gem has already been hosted in RubyGems.org.
So, we've been suggested Bundler's github option to install this garage
gem, but it has some downsides. The biggest one is users can not install
the gem in the default way. Another one is users can not install the
gem while GitHub is down.

@cookpad/garage Are there any points which I forget to change or consider?