### PR TITLE
Require responders

### DIFF
--- a/lib/garage/app_responder.rb
+++ b/lib/garage/app_responder.rb
@@ -1,6 +1,5 @@
-if Rails::VERSION::MAJOR > 4 ||
-    (Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR >= 2)
-  require 'action_controller/responder'
+if Rails.gem_version >= Gem::Version.new('4.2.0')
+  require 'responders'
 else
   require 'action_controller'
 end


### PR DESCRIPTION
Related to https://github.com/cookpad/garage/pull/10.

When I included `Garage::ControllerHelper` in controller, I got the following error.
(It didn't happen when I wrote `gem 'responders'` in Gemfile.)

```
     ActionController::RoutingError:
       undefined method `respond_to' for FooController:Class
       Did you mean?  respond_to?
```

I think not only `action_controller/responder` but also `action_controller/respond_with` are necessary. I changed garage to automatically require 'responders' to define `ActionController::RespondWith.respond_to` because it allows us to require them lazily.