### PR TITLE
Fully support the "presentation layer design"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In your Rails model class:
 ```ruby
 class Employee < ActiveRecord::Base
   include Garage::Representer
+  include Garage::Authorizable
 
   belongs_to :division
   has_many :projects
@@ -54,6 +55,34 @@ class EmployeesController < ApplicationController
 
   def require_resources
     @resources = Employee.all
+  end
+end
+```
+
+## Create decorator for your AR models
+With not small application, you may add a presentation layer to build API responses.
+Define a decorator class with `Resource` suffix and define `#to_resource` in
+your AR model.
+
+```ruby
+class User < ActiveRecord::Base
+  def to_resource
+    UserResource.new(self)
+  end
+end
+
+class UserResource
+  include Garage::Representer
+  include Garage::Authorizable
+
+  property :id
+  property :name
+  property :email
+
+  delegate :id, :name, :email, to: :@model
+
+  def initialize(model)
+    @model = model
   end
 end
 ```

--- a/lib/garage/restful_actions.rb
+++ b/lib/garage/restful_actions.rb
@@ -32,7 +32,22 @@ module Garage
       end
 
       def resource_class
-        @resource_class ||= name.sub(/Controller\z/, '').demodulize.singularize.constantize
+        @resource_class ||= resource_class_name.constantize
+      end
+
+      private
+
+      def resource_class_name
+        class_name = name.sub(/Controller\z/, '').demodulize.singularize
+        class_name_with_suffix = "#{class_name}Resource"
+        case
+        when const_defined?(class_name_with_suffix)
+          class_name_with_suffix
+        when const_defined?(class_name)
+          class_name
+        else
+          raise "Garage needs `#{class_name}Resource` or `#{class_name}` for resource class of #{name} but neither was found. If you want use an alternative class for the resource class, specify the resource class by `.resource_class=` in your controller."
+        end
       end
     end
 
@@ -173,7 +188,7 @@ module Garage
       elsif @resources
         MetaResource.new(self.class.resource_class)
       else
-        @resource
+        Garage.configuration.cast_resource.call(@resource)
       end
     end
 

--- a/lib/garage/restful_actions.rb
+++ b/lib/garage/restful_actions.rb
@@ -32,21 +32,21 @@ module Garage
       end
 
       def resource_class
-        @resource_class ||= resource_class_name.constantize
+        @resource_class ||= default_resource_class
       end
 
       private
 
-      def resource_class_name
+      def default_resource_class
         class_name = name.sub(/Controller\z/, '').demodulize.singularize
-        class_name_with_suffix = "#{class_name}Resource"
-        case
-        when const_defined?(class_name_with_suffix)
-          class_name_with_suffix
-        when const_defined?(class_name)
-          class_name
-        else
-          raise "Garage needs `#{class_name}Resource` or `#{class_name}` for resource class of #{name} but neither was found. If you want use an alternative class for the resource class, specify the resource class by `.resource_class=` in your controller."
+        begin
+          return "#{class_name}Resource".constantize
+        rescue NameError
+          begin
+            return class_name.constantize
+          rescue NameError
+            raise "Garage needs `#{class_name}Resource` or `#{class_name}` for resource class of #{name} but neither was found. If you want use an alternative class for the resource class, specify the resource class by `.resource_class=` in your controller."
+          end
         end
       end
     end

--- a/spec/dummy/app/controllers/campaigns_controller.rb
+++ b/spec/dummy/app/controllers/campaigns_controller.rb
@@ -1,0 +1,11 @@
+class CampaignsController < ApiController
+  include Garage::RestfulActions
+
+  def require_resource
+    @resource = Campaign.find(params[:id])
+  end
+
+  def require_resources
+    @resources = Campaign.all
+  end
+end

--- a/spec/dummy/app/models/campaign.rb
+++ b/spec/dummy/app/models/campaign.rb
@@ -1,0 +1,5 @@
+class Campaign < ActiveRecord::Base
+  def to_resource
+    CampaignResource.new(self)
+  end
+end

--- a/spec/dummy/app/models/campaign_resource.rb
+++ b/spec/dummy/app/models/campaign_resource.rb
@@ -1,0 +1,21 @@
+class CampaignResource
+  include Garage::Representer
+  include Garage::Authorizable
+
+  def self.build_permissions(perms, other, target)
+    perms.permits! :read, :write
+  end
+
+  property :id
+  delegate :id, to: :@model
+
+  link(:self) { campaign_path(@model) }
+
+  def initialize(model)
+    @model = model
+  end
+
+  def build_permissions(perms, other)
+    perms.permits! :read, :write
+  end
+end

--- a/spec/dummy/config/initializers/garage.rb
+++ b/spec/dummy/config/initializers/garage.rb
@@ -18,6 +18,8 @@ Garage.configuration.strategy = Garage::Strategy::Test
 Garage::TokenScope.configure do
   register :public do
     access :read, Post
+    access :read, CampaignResource
+    access :write, CampaignResource
   end
 
   register :read_private_post do

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     resources :public_posts, only: :index
   end
 
+  resources :campaigns
   resource :session
   resource :echo
   resource :ping

--- a/spec/dummy/db/migrate/20160509085057_create_campaigns.rb
+++ b/spec/dummy/db/migrate/20160509085057_create_campaigns.rb
@@ -1,0 +1,8 @@
+class CreateCampaigns < ActiveRecord::Migration
+  def change
+    create_table :campaigns do |t|
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,14 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141209001746) do
+ActiveRecord::Schema.define(version: 20160509085057) do
+
+  create_table "campaigns", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "comments", force: :cascade do |t|
     t.integer  "user_id",    limit: 4
     t.integer  "post_id",    limit: 4
     t.string   "body",       limit: 255
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|
@@ -54,8 +59,8 @@ ActiveRecord::Schema.define(version: 20141209001746) do
     t.string   "uid",          limit: 255,              null: false
     t.string   "secret",       limit: 255,              null: false
     t.string   "redirect_uri", limit: 255,              null: false
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "scopes",       limit: 255, default: "", null: false
   end
 
@@ -65,15 +70,15 @@ ActiveRecord::Schema.define(version: 20141209001746) do
     t.integer  "user_id",    limit: 4
     t.string   "title",      limit: 255
     t.string   "body",       limit: 255
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "users", force: :cascade do |t|
     t.string   "name",       limit: 255
     t.string   "email",      limit: 255
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end

--- a/spec/factories/campaigns.rb
+++ b/spec/factories/campaigns.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :campaign do
+    
+  end
+end

--- a/spec/requests/resource_conversion_spec.rb
+++ b/spec/requests/resource_conversion_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe 'Resource conversion' do
+  include AuthenticatedContext
+  let(:header) { { Accept: 'application/json' } }
+
+  describe 'RestfulActions' do
+    it 'uses `XxxResource` class as a default resource class' do
+      FactoryGirl.create(:campaign)
+
+      get '/campaigns', {}, header
+      expect(response.status).to eq(200)
+      expect(response.body).to be_json_including(
+        [
+          { 'id' => Integer },
+        ]
+      )
+    end
+
+    it 'uses `Xxx` class as a fallback' do
+      FactoryGirl.create(:post)
+
+      get '/posts', {}, header
+      expect(response.status).to eq(200)
+      expect(response.body).to be_json_including(
+        [
+          { 'id' => Integer, 'title' => String },
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
Convert to resource before checking permissions.

We often create a presentation layer to define Garage resource
definition instead of defining resource definition in the AR model
directly. In that case, Garage automatically converts AR models
to resource objects by calling `to_resource` method on them, but Garage
does not convert AR models to resource objects on checking permissions.
By this change, patching Garage's RestfulActions or converting to
resource object by hand become unnecessary.