### PR TITLE
Users can access configuration object without initialization

### DIFF
--- a/lib/garage/config.rb
+++ b/lib/garage/config.rb
@@ -6,7 +6,7 @@ module Garage
   end
 
   def self.configuration
-    @config
+    @config ||= configure {}
   end
 
   class Config


### PR DESCRIPTION
This omit the boilerplate:

    Garage.configure {}