### PR TITLE
Hold raw response of auth server in AccessToken

### DIFF
--- a/lib/garage/strategy/access_token.rb
+++ b/lib/garage/strategy/access_token.rb
@@ -1,9 +1,10 @@
 module Garage
   module Strategy
     class AccessToken
-      attr_reader :scope, :token, :token_type
+      attr_reader :scope, :token, :token_type, :raw_response
 
       def initialize(attrs)
+        @raw_response = attrs
         @scope, @token, @token_type = attrs[:scope], attrs[:token], attrs[:token_type]
         @application_id, @resource_owner_id = attrs[:application_id], attrs[:resource_owner_id]
         @expired_at, @revoked_at = attrs[:expired_at], attrs[:revoked_at]

--- a/spec/garage/strategy/auth_server_spec.rb
+++ b/spec/garage/strategy/auth_server_spec.rb
@@ -77,6 +77,19 @@ RSpec.describe Garage::Strategy::AuthServer do
           expect(token).to be_nil
         end
       end
+
+      context 'when auth server returns optional value' do
+        before do
+          response[:client_id] = 'client_id'
+          stub_request(:get, auth_server_url).to_return(status: 200, body: response.to_json)
+        end
+
+        it 'returns valid access token' do
+          token = fetcher.fetch(request)
+          expect(token).to be_accessible
+          expect(token.raw_response[:client_id]).to eq 'client_id'
+        end
+      end
     end
 
     describe '.fetch with caching' do


### PR DESCRIPTION
so that a garage application can retrieve custom response values from backend auth server.