### PR TITLE
Add label for scope checkbox

### DIFF
--- a/app/views/garage/docs/resources/console.html.haml
+++ b/app/views/garage/docs/resources/console.html.haml
@@ -37,8 +37,9 @@
     = hidden_field_tag :return_to, request.fullpath
     .modal-body
       - Garage::TokenScope.revealed_scopes.each do |scope|
-        = check_box_tag "scopes[]", scope, :selected => true
-        = scope
+        %label
+          = check_box_tag "scopes[]", scope, :selected => true
+          = scope
         %br
     .modal-footer
       = button_tag "Close", :class => "modal-close"


### PR DESCRIPTION
Currently, scope name is not clickable in console page.
![1472557861](https://cloud.githubusercontent.com/assets/4361134/18088087/76cb51ea-6ef3-11e6-8e6e-f9fc5bdb85af.png)
Click public in the above modal, don't toggle the checkbox.

So, I've added a label for the checkbox.

![console](https://cloud.githubusercontent.com/assets/4361134/18088250/856b283c-6ef4-11e6-874d-b5e9ca0e6b77.gif)
