### PR TITLE
Update documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,9 +1,17 @@
 # Contributing
-## Development tips
+
+## Testing
+
+First, prepare a database for the test.
+
+```sh
+bundle install
+RAILS_ENV=test bundle exec rake db:create db:migrate
+```
+
 We use [Appraisal](https://github.com/thoughtbot/appraisal) to test with different versions of Rails.
 
 ```
-bundle install
 appraisal install
 
 # Run with specific version of Rails
@@ -13,13 +21,18 @@ appraisal rails-4.1 rspec
 appraisal rspec
 ```
 
+## Run local server
+
 When run local server, use multithreaded server and specify some environment variables.
-If you have not created oauth application in development environment, create it with
+If you have not created OAuth application in development environment, create it with
 `rails console` command.
 
 ```
-# In spec/dummy
+bundle exec rake db:create db:migrate
+cd spec/dummy/
 GARAGE_REMOTE_SERVER=http://localhost:3000/ \
   GARAGE_CONSOLE_APP_UID=$ANY_CONSOLE_APP_UID \
   bundle exec puma -t '2:10' -p3000
 ```
+
+You can get an information of resources in `http://localhost:3000/docs`.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ module MyStrategy
 end
 ```
 
+## Development
+
+See [DEVELOPMENT.md](DEVELOPMENT.md).
+
 ## Authors
 
 * Tatsuhiko Miyagawa


### PR DESCRIPTION
### Rename `CONTRIBUTING.md` to `DEVELOPMENT.md`

I think `CONTRIBUTING.md` is a guidline for contributing.
(GitHub says the following message in a new PR creation page)
<img width="567" alt="screen shot 2016-09-01 at 16 36 33" src="https://cloud.githubusercontent.com/assets/4361134/18159173/835047b6-7062-11e6-86cc-8802e62b1239.png">


However the file is not a guidline. This is development tips.
So, I've renamed the file to `DEVELOPMENT.md`.



### Update content

I've added preparing of development information(`rake db:migrate`) into the document.