### PR TITLE
Set current path with query parameters to `return_to`

### DIFF
--- a/app/assets/javascripts/garage/docs/console.js.coffee
+++ b/app/assets/javascripts/garage/docs/console.js.coffee
@@ -10,6 +10,7 @@ jQuery ()->
     ev.preventDefault()
 
   $("#oauth-dialog .authenticate").click (ev) ->
+    $("#oauth-dialog #return_to").val(window.location.pathname + window.location.search)
     $("form#oauth-authenticate").submit()
     ev.preventDefault()
 

--- a/app/controllers/garage/docs/resources_controller.rb
+++ b/app/controllers/garage/docs/resources_controller.rb
@@ -85,7 +85,7 @@ class Garage::Docs::ResourcesController < Garage::ApplicationController
 
   def require_console_application
     @app = console_application
-    unless @app[:uid] && @app[:secret]
+    if @app[:uid].blank? || @app[:secret].blank?
       render(text: 'Configuration for console application is missing.', status: :forbidden)
     end
   end

--- a/lib/garage/docs/config.rb
+++ b/lib/garage/docs/config.rb
@@ -13,7 +13,7 @@ module Garage
         @document_root = Rails.root.join('doc/garage')
         @current_user_method = Proc.new { current_user }
         @authenticate = Proc.new {}
-        @console_app_uid = ''
+        @console_app_uid, @console_app_secret = nil, nil
         @remote_server = Proc.new {|request| "#{request.protocol}#{request.host_with_port}" }
         @docs_authorization_method = nil
         @docs_cache_enabled = true

--- a/spec/dummy/config/initializers/garage.rb
+++ b/spec/dummy/config/initializers/garage.rb
@@ -3,8 +3,8 @@ Garage.configure do
     extend CurrentUserHelper
     current_user
   }
-  docs.console_app_uid = ENV['GARAGE_CONSOLE_APP_UID'] || ''
-  docs.console_app_secret = ENV['GARAGE_CONSOLE_APP_SECRET'] || ''
+  docs.console_app_uid = ENV['GARAGE_CONSOLE_APP_UID']
+  docs.console_app_secret = ENV['GARAGE_CONSOLE_APP_SECRET']
 
   if ENV['GARAGE_REMOTE_SERVER']
     docs.remote_server = ENV['GARAGE_REMOTE_SERVER']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
 ENV["RAILS_ENV"] ||= "test"
+ENV['GARAGE_CONSOLE_APP_UID'] ||= 'dummy'
+ENV['GARAGE_CONSOLE_APP_SECRET'] ||= 'dummy'
+
 require "garage"
 
 require File.expand_path("../dummy/config/environment", __FILE__)


### PR DESCRIPTION
This enables us to get token with current query strings in garage console page.

@cookpad/dev-infra Please take a look this 👓 