### PR TITLE
Don't use Fixnum and Bignum in Ruby 2.4

### DIFF
--- a/lib/garage/representer.rb
+++ b/lib/garage/representer.rb
@@ -166,22 +166,24 @@ module Garage::Representer
       end
     end
 
+    PRIMITIVE_CLASSES = [
+      ActiveSupport::TimeWithZone,
+      Date,
+      Time,
+      Integer,
+      Float,
+      Hash,
+      Array,
+      String,
+      NilClass,
+      TrueClass,
+      FalseClass,
+      Symbol,
+    ]
+    PRIMITIVE_CLASSES.push(Fixnum, Bignum) unless 0.class == Integer
+
     def primitive?(value)
-      [
-        ActiveSupport::TimeWithZone,
-        Date,
-        Time,
-        Bignum,
-        Fixnum,
-        Float,
-        Hash,
-        Array,
-        String,
-        NilClass,
-        TrueClass,
-        FalseClass,
-        Symbol,
-      ].any? {|k| value.is_a?(k) }
+      PRIMITIVE_CLASSES.any? {|k| value.is_a?(k) }
     end
 
     private

--- a/lib/garage/representer.rb
+++ b/lib/garage/representer.rb
@@ -180,7 +180,6 @@ module Garage::Representer
       FalseClass,
       Symbol,
     ]
-    PRIMITIVE_CLASSES.push(Fixnum, Bignum) unless 0.class == Integer
 
     def primitive?(value)
       PRIMITIVE_CLASSES.any? {|k| value.is_a?(k) }


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/12739

I got following warnings.

```
/usr/share/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/the_garage-2.3.2/lib/garage/representer.rb:175: warning: constant ::Fixnum is deprecated
/usr/share/rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/the_garage-2.3.2/lib/garage/representer.rb:174: warning: constant ::Bignum is deprecated
```

This patch fixes them in the same way as https://github.com/rails/rails/pull/26732.