### PR TITLE
Unpin oj version

### DIFF
--- a/garage.gemspec
+++ b/garage.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", '>= 4.0.0'
   s.add_dependency "rack-accept-default", "~> 0.0.2"
-  s.add_dependency "oj", "< 2.18.0" # FIXME: Use oj >= 2.18 and pass specs with Rails 5
+  s.add_dependency "oj"
   s.add_dependency "responders"
   s.add_dependency "oauth2"
   s.add_dependency "redcarpet", ">= 3.1.1"

--- a/lib/garage/hypermedia_responder.rb
+++ b/lib/garage/hypermedia_responder.rb
@@ -91,7 +91,7 @@ module Garage
       end
 
       def render
-        Oj.dump(converted_data, mode: :compat).gsub(/([<>])/, JSON_ESCAPE_TABLE)
+        Oj.dump(converted_data, mode: :compat, use_as_json: true).gsub(/([<>])/, JSON_ESCAPE_TABLE)
       end
 
       private


### PR DESCRIPTION
As of 2.18.0, oj desn't use `#to_json` method to dump non-primitive
objects such as AS::TimeWithZone or any AR objects. We have to specify
`use_as_json` option explicitly to dump as "compact". ref: https://github.com/ohler55/oj/blob/49a1f04adccbebb17dbfacab1143471a3772b1bb/CHANGELOG.md#2180---2016-11-26

@cookpad/dev-infra 👓 ?