### PR TITLE
Don't dump AC::Parameters directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ matrix:
     - rvm: 2.1.10
       gemfile: gemfiles/rails_5.0.gemfile
 before_script:
-  - RAILS_ENV=test bundle exec rake db:create db:migrate
+  - RAILS_ENV=test bundle exec rake db:setup

--- a/spec/garage/hypermedia_responder_spec.rb
+++ b/spec/garage/hypermedia_responder_spec.rb
@@ -78,7 +78,7 @@ describe Garage::HypermediaResponder do
           param :key1
 
           def render_hash(options = {})
-            params
+            params.as_json
           end
         end
       end


### PR DESCRIPTION
Its `#as_json` can be changed.

A fix for the test failure like https://travis-ci.org/cookpad/garage/builds/225516684.