### PR TITLE
Add protect_from_forgery with: :null_session to ControllerHelper

### DIFF
--- a/lib/garage/controller_helper.rb
+++ b/lib/garage/controller_helper.rb
@@ -20,6 +20,8 @@ module Garage
 
       respond_to :json # , :msgpack
       self.responder = Garage::AppResponder
+
+      protect_from_forgery with: :null_session
     end
 
     # For backword compatiblility.


### PR DESCRIPTION
I think that `protect_from_forgery with: :null_session` is the default.
What about it?