### PR TITLE
Support distributed tracing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "kaminari", "< 1"
 gem "responders"
 
 group :development, :test do
+  gem "aws-xray", '>= 0.9.6'
   gem "rspec-rails"
   gem "mysql2"
   gem "pry-rails"

--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ Currently, we support following tracers:
 ```ruby
 # e.g. aws-xray tracer
 require 'aws/xray'
-Garage.configuration.tracing = { tracer: 'aws-xray', service: 'some-name' }
+Garage::Tracer::AwsXrayTracer.service = 'your-auth-server-name'
+Garage.configuration.tracer = Garage::Tracer::AwsXrayTracer
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -187,6 +187,20 @@ module MyStrategy
 end
 ```
 
+## Distributed tracing
+In case you use auth-server strategy, you can setup distributed tracing for the service communication between garage application and auth server.
+Currently, we support following tracers:
+
+- `aws-xray` using [aws-xray](https://github.com/taiki45/aws-xray) gem.
+  - Bundle `aws-xray` gem in your application.
+  - Configure `service` option for a logical service name of the auth server.
+
+```ruby
+# e.g. aws-xray tracer
+require 'aws/xray'
+Garage.configuration.tracing = { tracer: 'aws-xray', service: 'some-name' }
+```
+
 ## Development
 
 See [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -8,6 +8,7 @@ gem "responders"
 gem "jquery-rails"
 
 group :development, :test do
+  gem "aws-xray", ">= 0.9.6"
   gem "rspec-rails"
   gem "mysql2"
   gem "pry-rails"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -8,6 +8,7 @@ gem "responders"
 gem "jquery-rails"
 
 group :development, :test do
+  gem "aws-xray", ">= 0.9.6"
   gem "rspec-rails"
   gem "mysql2"
   gem "pry-rails"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -8,6 +8,7 @@ gem "responders"
 gem "jquery-rails"
 
 group :development, :test do
+  gem "aws-xray", ">= 0.9.6"
   gem "rspec-rails"
   gem "mysql2"
   gem "pry-rails"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -8,6 +8,7 @@ gem "responders"
 gem "jquery-rails"
 
 group :development, :test do
+  gem "aws-xray", ">= 0.9.6"
   gem "rspec-rails"
   gem "mysql2"
   gem "pry-rails"

--- a/lib/garage/config.rb
+++ b/lib/garage/config.rb
@@ -36,6 +36,16 @@ module Garage
       instance_variable_defined?(:@strategy) ? @strategy : Garage::Strategy::NoAuthentication
     end
 
+    # Support distributed tracing for auth server accesses.
+    #
+    # @param [Hash] tracing a hash with
+    #   - `tracer`: specify tracing method.
+    #   - `service`: specify logical service name of auth server.
+    attr_writer :tracing
+    def tracing
+      @tracing ||= {}
+    end
+
     def docs
       @docs ||= Docs::Config.new
     end

--- a/lib/garage/config.rb
+++ b/lib/garage/config.rb
@@ -38,12 +38,10 @@ module Garage
 
     # Support distributed tracing for auth server accesses.
     #
-    # @param [Hash] tracing a hash with
-    #   - `tracer`: specify tracing method.
-    #   - `service`: specify logical service name of auth server.
-    attr_writer :tracing
-    def tracing
-      @tracing ||= {}
+    # @param [Ojbect] tracer an object which implements tracer methods. See Garage::Tracer::NullTracer.
+    attr_writer :tracer
+    def tracer
+      @tracer ||= Garage::Tracer::NullTracer
     end
 
     def docs

--- a/lib/garage/tracer.rb
+++ b/lib/garage/tracer.rb
@@ -8,12 +8,7 @@ module Garage
     private
 
     def tracer
-      case Garage.configuration.tracing[:tracer]
-      when 'aws-xray'
-        AwsXrayTracer
-      else
-        NullTracer
-      end
+      Garage.configuration.tracer
     end
 
     # Any tracers must have `.start` to start tracing context and:
@@ -45,9 +40,13 @@ module Garage
     end
 
     class AwsXrayTracer
+      class << self
+        attr_accessor :service
+      end
+
       def self.start(&block)
         if Aws::Xray::Context.started?
-          Aws::Xray::Context.current.child_trace(remote: true, name: Garage.configuration.tracing[:service]) do |sub|
+          Aws::Xray::Context.current.child_trace(remote: true, name: service) do |sub|
             yield new(sub)
           end
         else

--- a/lib/garage/tracer.rb
+++ b/lib/garage/tracer.rb
@@ -1,0 +1,90 @@
+module Garage
+  module Tracer
+    extend self
+    extend Forwardable
+
+    def_delegators :tracer, :start, :inject_trace_context, :record_http_request, :record_http_response
+
+    private
+
+    def tracer
+      case Garage.configuration.tracing[:tracer]
+      when 'aws-xray'
+        AwsXrayTracer
+      else
+        NullTracer
+      end
+    end
+
+    # Any tracers must have `.start` to start tracing context and:
+    #   - `#inject_trace_context` to add tracing context to the given request header.
+    #   - `#record_http_request` to record http request in tracer.
+    #   - `#record_http_response` to recrod http response in tracer.
+    class NullTracer
+      def self.start(&block)
+        yield new
+      end
+
+      # @param [Hash] header
+      # @return [Hash]
+      def inject_trace_context(header)
+        header
+      end
+
+      # @param [String] method
+      # @param [String] url
+      # @param [String] user_agent
+      # @return [nil]
+      def record_http_request(method, url, user_agent)
+      end
+
+      # @param [Integer] status
+      # @param [Integer] content_length
+      def record_http_response(status, content_length)
+      end
+    end
+
+    class AwsXrayTracer
+      def self.start(&block)
+        if Aws::Xray::Context.started?
+          Aws::Xray::Context.current.child_trace(remote: true, name: Garage.configuration.tracing[:service]) do |sub|
+            yield new(sub)
+          end
+        else
+          yield NullTracer.new
+        end
+      end
+
+      def initialize(sub_segment)
+        @sub = sub_segment
+      end
+
+      def inject_trace_context(header)
+        header.merge('X-Amzn-Trace-Id' => @sub.generate_trace.to_header_value)
+      end
+
+      def record_http_request(method, url, user_agent)
+        request = Aws::Xray::Request.build(method: method.to_s.upcase, url: url, user_agent: user_agent)
+        @sub.set_http_request(request)
+      end
+
+      def record_http_response(status, content_length)
+        @sub.set_http_response(status, content_length || 0)
+
+        case status
+        when 499
+          cause = Aws::Xray::Cause.new(stack: caller, message: 'Got 499', type: 'http_request_error')
+          @sub.set_error(error: true, throttle: true, cause: cause)
+        when 400..498
+          cause = Aws::Xray::Cause.new(stack: caller, message: 'Got 4xx', type: 'http_request_error')
+          @sub.set_error(error: true, cause: cause)
+        when 500..599
+          cause = Aws::Xray::Cause.new(stack: caller, message: 'Got 5xx', type: 'http_request_error')
+          @sub.set_error(fault: true, remote: true, cause: cause)
+        else
+          # pass
+        end
+      end
+    end
+  end
+end

--- a/spec/garage/strategy/auth_server_spec.rb
+++ b/spec/garage/strategy/auth_server_spec.rb
@@ -179,12 +179,13 @@ RSpec.describe Garage::Strategy::AuthServer do
         end
 
         around do |ex|
-          back = Garage.configuration.tracing
-          Garage.configuration.tracing = { tracer: 'aws-xray', service: 'auth-server' }
+          back = Garage.configuration.tracer
+          Garage::Tracer::AwsXrayTracer.service = 'auth-server'
+          Garage.configuration.tracer = Garage::Tracer::AwsXrayTracer
           Aws::Xray::Context.with_new_context('test-app', xray_client, trace) do
             Aws::Xray::Context.current.base_trace { ex.run }
           end
-          Garage.configuration.tracing = back
+          Garage.configuration.tracer = back
         end
 
         let(:xray_client) { Aws::Xray::Client.new(sock: io) }


### PR DESCRIPTION
To support distributed tracing between garage application and authorization server, add configuration and propagation logic.

At first, we use aws-xray tracer. But tracers are configurable and users should be able to choose or implement another tracing method.

@cookpad/dev-infra Please take a look at this.