### PR TITLE
Use disable_trace to disable net/http hook

### DIFF
--- a/lib/garage/tracer.rb
+++ b/lib/garage/tracer.rb
@@ -47,7 +47,11 @@ module Garage
       def self.start(&block)
         if Aws::Xray::Context.started?
           Aws::Xray::Context.current.child_trace(remote: true, name: service) do |sub|
-            yield new(sub)
+            if Aws::Xray::Context.current.respond_to?(:disable_trace)
+              Aws::Xray::Context.current.disable_trace(:net_http) { yield new(sub) }
+            else
+              yield new(sub)
+            end
           end
         else
           yield NullTracer.new


### PR DESCRIPTION
As aws-xray implements net/http hook, we should disable the hook in garage's tracer to avoid recording http requests twice: https://github.com/taiki45/aws-xray/pull/39

Check method availabiity because we can specify the version of dependent
gem (aws-xray) here...

@cookpad/dev-infra Please take a look.