### PR TITLE
Switch to use net/http hook to implement distributed tracing support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "kaminari", "< 1"
 gem "responders"
 
 group :development, :test do
-  gem "aws-xray", '>= 0.9.6'
+  gem "aws-xray", '>= 0.20.0'
   gem "rspec-rails"
   gem "mysql2"
   gem "pry-rails"

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Currently, we support following tracers:
 
 ```ruby
 # e.g. aws-xray tracer
-require 'aws/xray'
+require 'aws/xray/hooks/net_http'
 Garage::Tracer::AwsXrayTracer.service = 'your-auth-server-name'
 Garage.configuration.tracer = Garage::Tracer::AwsXrayTracer
 ```

--- a/spec/garage/strategy/auth_server_spec.rb
+++ b/spec/garage/strategy/auth_server_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'aws/xray'
+require 'aws/xray/hooks/net_http'
 
 RSpec.describe Garage::Strategy::AuthServer do
   before do


### PR DESCRIPTION
Now aws-xray gem supports net/http hook. Switch to use the feature.

**pros**

- Less code.
- Less dependency to aws-xray gem. Garage will only dependent to passing one header (`X-Aws-Xray-Name` header).

**cons**

- Drop support of distributed tracing when the application does not use aws-xray's net/http hook.
  - But since most of applications using aws-xray use net/http hook, the impact of this will be small.

@cookpad/dev-infra FYI