### PR TITLE
Update ruby and rails for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.1.10
-  - 2.2.6
-  - 2.3.3
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 gemfile:
   - gemfiles/rails_4.0.gemfile
   - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_5.0.gemfile
-matrix:
-  exclude:
-    # Rails 5 or later requires Ruby 2.2.0 or newer.
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails_5.0.gemfile
 before_script:
   - RAILS_ENV=test bundle exec rake db:setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,7 @@ rvm:
 gemfile:
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_5.0.gemfile
+  - gemfiles/rails_5.1.gemfile
+  - gemfiles/rails_5.2.gemfile
 before_script:
   - RAILS_ENV=test bundle exec rake db:setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ rvm:
   - 2.5.5
   - 2.6.3
 gemfile:
-  - gemfiles/rails_4.0.gemfile
-  - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_5.0.gemfile
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,8 @@ gemfile:
   - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.2.gemfile
+before_install:
+  - "[[ $BUNDLE_GEMFILE =~ rails_4\\.2 ]] && gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true"
+  - "[[ $BUNDLE_GEMFILE =~ rails_4\\.2 ]] && gem install bundler -v '< 2' || true"
 before_script:
   - RAILS_ENV=test bundle exec rake db:setup

--- a/Appraisals
+++ b/Appraisals
@@ -1,15 +1,15 @@
-appraise 'rails-4.0' do
-  gem 'rails', '~> 4.0'
-end
-
-appraise 'rails-4.1' do
-  gem 'rails', '~> 4.1'
-end
-
 appraise 'rails-4.2' do
   gem 'rails', '~> 4.2'
 end
 
 appraise 'rails-5.0' do
   gem 'rails', '~> 5.0'
+end
+
+appraise 'rails-5.1' do
+  gem 'rails', '~> 5.1'
+end
+
+appraise 'rails-5.2' do
+  gem 'rails', '~> 5.2'
 end

--- a/app/views/layouts/garage/application.html.haml
+++ b/app/views/layouts/garage/application.html.haml
@@ -6,7 +6,7 @@
     = csrf_meta_tags
     = stylesheet_link_tag "garage/application", :media => "all"
     = javascript_include_tag "garage/application"
-    = favicon_link_tag "favicon.ico"
+    = favicon_link_tag "favicon.ico", skip_pipeline: true
 
   %body{ class: action_classes }
     .navbar.navbar-default.navbar-static-top

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 4.0"
+gem "rails", "~> 5.1"
 gem "kaminari", "< 1"
 gem "responders"
 gem "jquery-rails"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 4.1"
+gem "rails", "~> 5.2"
 gem "kaminari", "< 1"
 gem "responders"
 gem "jquery-rails"

--- a/lib/garage/tracer.rb
+++ b/lib/garage/tracer.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Garage
   module Tracer
     extend self

--- a/spec/requests/field_loading_spec.rb
+++ b/spec/requests/field_loading_spec.rb
@@ -21,7 +21,7 @@ describe "Field loading API", type: :request do
       it "returns default fields" do
         is_expected.to eq(200)
         expect(response.body).to be_json_as(
-          id: Fixnum,
+          id: Integer,
           title: String,
           _links: Hash,
         )
@@ -36,7 +36,7 @@ describe "Field loading API", type: :request do
       it "returns default and user fields" do
         is_expected.to eq(200)
         expect(response.body).to be_json_as(
-          id: Fixnum,
+          id: Integer,
           title: String,
           user: Hash,
           _links: Hash,
@@ -52,7 +52,7 @@ describe "Field loading API", type: :request do
       it "returns all fields" do
         is_expected.to eq(200)
         expect(response.body).to be_json_as(
-          id: Fixnum,
+          id: Integer,
           title: String,
           label: String,
           user: Hash,
@@ -69,7 +69,7 @@ describe "Field loading API", type: :request do
 
       it "returns only id field" do
         is_expected.to eq(200)
-        expect(response.body).to be_json_as(id: Fixnum)
+        expect(response.body).to be_json_as(id: Integer)
       end
     end
 
@@ -81,7 +81,7 @@ describe "Field loading API", type: :request do
       it "returns only id and title fields" do
         is_expected.to eq(200)
         expect(response.body).to be_json_as(
-          id: Fixnum,
+          id: Integer,
           title: String,
           label: String
         )
@@ -97,7 +97,7 @@ describe "Field loading API", type: :request do
         is_expected.to eq(200)
         expect(response.body).to be_json_as(
           user: {
-            id: Fixnum,
+            id: Integer,
           },
         )
       end
@@ -113,7 +113,7 @@ describe "Field loading API", type: :request do
         expect(response.body).to be_json_as(
           comments: [
             {
-              id: Fixnum,
+              id: Integer,
               body: String,
               commenter: Hash,
               post_owner: Hash,
@@ -133,7 +133,7 @@ describe "Field loading API", type: :request do
         expect(response.body).to be_json_as(
           comments: [
             {
-              id: Fixnum,
+              id: Integer,
               body: String,
               commenter: Hash,
               post_owner: Hash,
@@ -154,7 +154,7 @@ describe "Field loading API", type: :request do
           comments: [
             {
               commenter: {
-                id: Fixnum,
+                id: Integer,
               },
             },
           ],
@@ -175,10 +175,10 @@ describe "Field loading API", type: :request do
     context "with caching" do
       it "caches response per params[:fields]" do
         is_expected.to eq(200)
-        expect(response.body).to be_json_as([{ id: Fixnum, title: String, _links: Hash }])
+        expect(response.body).to be_json_as([{ id: Integer, title: String, _links: Hash }])
         params[:fields] = "id"
         get path, params, env
-        expect(response.body).to be_json_as([{ id: Fixnum }])
+        expect(response.body).to be_json_as([{ id: Integer }])
       end
     end
 


### PR DESCRIPTION
I Updated ruby/rails to currently active versions for CI. The following changes fixes warnings caused by update versions.

- https://github.com/cookpad/garage/commit/4e0386f0b32183b3d1ba083a259ba46686f97d4c
  - Fix for: `warning: constant ::Fixnum is deprecated`
- https://github.com/cookpad/garage/commit/5203eefa55e9329e443994d33042d48cb4b087c6
  - Fix for: `DEPRECATION WARNING: The asset "favicon.ico" is not present in the asset pipeline.Falling back to an asset that may be in the public folder.` on `rails >= 5.1`
  - ref: https://github.com/rails/rails/pull/26226
  - I confirmed rails 4.2 and 5.0 work as before.

@cookpad/infra please review.
