### PR TITLE
Include selector string to cache key

### DIFF
--- a/lib/garage/hypermedia_responder.rb
+++ b/lib/garage/hypermedia_responder.rb
@@ -24,7 +24,9 @@ module Garage
     # `#resource_identifier` or `#id`.
     def encode_to_hash(resource, *args)
       if id = get_resource_identifier(resource)
-        cache_key = "#{resource.class.name}:#{id}"
+        options = args[0] || {}
+        selector = options[:selector] || controller.field_selector
+        cache_key = "#{resource.class.name}:#{id}:#{selector.canonical}"
         cache[cache_key] ||= _encode_to_hash(resource, *args)
       else
         _encode_to_hash(resource, *args)

--- a/spec/requests/field_loading_spec.rb
+++ b/spec/requests/field_loading_spec.rb
@@ -123,6 +123,37 @@ describe "Field loading API", type: :request do
       end
     end
 
+    context "with params[:fields] = 'comments[commenter[id],post_owner[id,name]]'" do
+      before do
+        params[:fields] = "comments[commenter[id],post_owner[id,name]]"
+      end
+
+      let(:post_a) do
+        FactoryGirl.create(:post, user: user)
+      end
+
+      let!(:comment) do
+        FactoryGirl.create(:comment, user: user, post: post_a)
+      end
+
+      it "returns different fields in commenter and post_owner" do
+        is_expected.to eq(200)
+        expect(response.body).to be_json_as(
+          comments: [
+            {
+              commenter: {
+                id: user.id,
+              },
+              post_owner: {
+                id: user.id,
+                name: user.name,
+              },
+            },
+          ],
+        )
+      end
+    end
+
     context "with params[:fields] = 'comments[*]'" do
       before do
         params[:fields] = "comments[*]"


### PR DESCRIPTION
## Problem

An unexpected behavior has occurred when identical resources and different selectors were specified in `fields`.

e.g. The following request does not return `name` for` post_owner`. `commenter` and` post_owner` are both `UserResource`.

```
$ curl 'http://localhost:3000/v1/posts?fields=comments[commenter[id],post_owner[id,name]]' | jq
[
  {
    "commenter": {
      "id": 1
    },
    "post_owner": {
      "id": 1
    }
  }
]
```

## Solution

This is because the cache key does not include a selector, so I added the selector string to cache key. It works fine.

```
$ curl 'http://localhost:3000/v1/posts?fields=comments[commenter[id],post_owner[id,name]]' | jq
[
  {
    "commenter": {
      "id": 1
    },
    "post_owner": {
      "id": 1,
      "name": "user name"
    }
  }
]
```

@cookpad/infra Please review.