### PR TITLE
Fix test errors

### DIFF
--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,4 @@
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css
+//= link garage/application.css
+//= link garage/application.js

--- a/spec/dummy/db/migrate/20130501215002_create_doorkeeper_tables.rb
+++ b/spec/dummy/db/migrate/20130501215002_create_doorkeeper_tables.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperTables < ActiveRecord::Migration
+class CreateDoorkeeperTables < ActiveRecord::Migration[4.2]
   def change
     create_table :oauth_applications do |t|
       t.string  :name,         :null => false

--- a/spec/dummy/db/migrate/20130501215033_create_users.rb
+++ b/spec/dummy/db/migrate/20130501215033_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :name

--- a/spec/dummy/db/migrate/20130501215056_create_posts.rb
+++ b/spec/dummy/db/migrate/20130501215056_create_posts.rb
@@ -1,4 +1,4 @@
-class CreatePosts < ActiveRecord::Migration
+class CreatePosts < ActiveRecord::Migration[4.2]
   def change
     create_table :posts do |t|
       t.integer :user_id

--- a/spec/dummy/db/migrate/20130508032709_create_comments.rb
+++ b/spec/dummy/db/migrate/20130508032709_create_comments.rb
@@ -1,4 +1,4 @@
-class CreateComments < ActiveRecord::Migration
+class CreateComments < ActiveRecord::Migration[4.2]
   def change
     create_table :comments do |t|
       t.integer :user_id

--- a/spec/dummy/db/migrate/20141209001746_add_scopes_to_oauth_applications.rb
+++ b/spec/dummy/db/migrate/20141209001746_add_scopes_to_oauth_applications.rb
@@ -1,4 +1,4 @@
-class AddScopesToOauthApplications < ActiveRecord::Migration
+class AddScopesToOauthApplications < ActiveRecord::Migration[4.2]
   def change
     add_column :oauth_applications, :scopes, :string, null: false, default: ''
   end

--- a/spec/dummy/db/migrate/20160509085057_create_campaigns.rb
+++ b/spec/dummy/db/migrate/20160509085057_create_campaigns.rb
@@ -1,4 +1,4 @@
-class CreateCampaigns < ActiveRecord::Migration
+class CreateCampaigns < ActiveRecord::Migration[4.2]
   def change
     create_table :campaigns do |t|
 


### PR DESCRIPTION
Fix errors related to gem upgrades:

1. Add a manifest for assets due to Sprockets 4.0
  * See also: https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs
2. Specify Rails version for ActiveRecord::Migration. Use 4.2 because its the minimum supported Rails version of Garage.

This allows tests to run locally, and should hopefully fix the errors in Travis CI