### PR TITLE
Proposal: Allow Resources casting to call to_resource with options

### DIFF
--- a/lib/garage/config.rb
+++ b/lib/garage/config.rb
@@ -49,11 +49,13 @@ module Garage
     end
 
     def cast_resource
-      @cast_resource ||= proc { |resource|
+      @cast_resource ||= proc { |resource, options|
+        options ||= {}
+        to_resource_args = [options[:cast_context]].compact
         if resource.respond_to?(:map) && resource.respond_to?(:to_a)
-          resource.map(&:to_resource)
+          resource.map { |r| r.to_resource(*to_resource_args) }
         else
-          resource.to_resource
+          resource.to_resource(*to_resource_args)
         end
       }
     end

--- a/lib/garage/representer.rb
+++ b/lib/garage/representer.rb
@@ -51,7 +51,7 @@ module Garage::Representer
     self.class
   end
 
-  def to_resource
+  def to_resource(options = {})
     self
   end
 

--- a/lib/garage/resource_casting_responder.rb
+++ b/lib/garage/resource_casting_responder.rb
@@ -6,7 +6,7 @@ module Garage::ResourceCastingResponder
 
   def display(resource, given_options={})
     if @caster
-      resource = @caster.call(resource)
+      resource = @caster.call(resource, @options)
     end
     super(resource, given_options)
   end

--- a/spec/dummy/app/controllers/campaigns_controller.rb
+++ b/spec/dummy/app/controllers/campaigns_controller.rb
@@ -8,4 +8,8 @@ class CampaignsController < ApiController
   def require_resources
     @resources = Campaign.all
   end
+
+  def respond_with_resource_options
+    { cast_context: { current_user: current_resource_owner } }
+  end
 end

--- a/spec/dummy/app/models/campaign.rb
+++ b/spec/dummy/app/models/campaign.rb
@@ -1,5 +1,5 @@
 class Campaign < ActiveRecord::Base
-  def to_resource
-    CampaignResource.new(self)
+  def to_resource(options = {})
+    CampaignResource.new(self, options)
   end
 end

--- a/spec/dummy/app/models/campaign_resource.rb
+++ b/spec/dummy/app/models/campaign_resource.rb
@@ -7,15 +7,21 @@ class CampaignResource
   end
 
   property :id
+  property :current_user_id
   delegate :id, to: :@model
 
   link(:self) { campaign_path(@model) }
 
-  def initialize(model)
+  def initialize(model, options = {})
     @model = model
+    @options = options
   end
 
   def build_permissions(perms, other)
     perms.permits! :read, :write
+  end
+
+  def current_user_id
+    @options[:current_user]&.id
   end
 end

--- a/spec/requests/resource_conversion_spec.rb
+++ b/spec/requests/resource_conversion_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe 'Resource conversion', type: :request do
       )
     end
 
+    it "builds resource from model with additional options" do
+      campaign = FactoryBot.create(:campaign)
+
+      get "/campaigns/#{campaign.id}", {}, header
+      expect(response.status).to eq(200)
+      expect(response.body).to be_json_including(
+        { 'id' => Integer, "current_user_id" => user.id }
+      )
+    end
+
     it 'uses `Xxx` class as a fallback' do
       FactoryBot.create(:post)
 


### PR DESCRIPTION
When casting to a resource, allow additional context to be used to render resources via the :cast_context key in the options for respond_with.

## Use Case

When rendering a resource, the controller may want to specify supply session-specific context (not directly related to the resource) to be rendered in the response. This can be achieved by passing additional options to `to_resource` in the controller, and skipping implicit casting of the model to resource. 

The approach of explicitly calling `to_resource` is undesirable in scenarios such as when pagination of a listing is required. A naive approach would be:

```ruby
def require_resources
   @resources = MyModel.relation.map { |r| r.to_resource(context: context) }
end
```
This can be a problem when pagination is also desired. Garage provides a `PaginatingResponder` can be triggered by setting `{ paginate: true }` as the respond_with option, but this approach is incompatible because the `map` will execute the query before pagination can be performed.

## Proposed Usage

Taking inspiration from [roar-rails](https://github.com/apotonick/roar-rails#passing-options) and [representable](https://github.com/trailblazer/representable#passing-options) (originally inspiration for Garage), I propose to allow the ResourceCastingResponder to pass the `respond_with` some "context" as options to the casting function (defined in Garage::Configuration), to be used in the call to `to_resource`. 

In practice, the programmer can set a `cast_context` in the options hash set with `respond_with_resources_options`, and deal with the options in their implementation of `to_resource`.

```ruby
# In a Restful Controller

def require_resources
  @resources = Delivery.includes(:items)
end

def respond_with_resource_options
  { paginate: true, cast_context { location: user_selected_location } }
end

## In Delivery model

def to_resource(options = {})
  location = options[:location] || default_location
  DeliveryResource.new(self, location: location)
end


## In DeliveryResource

def initialize(model, location:)
  @model = model
  @location = location  
end
```