### PR TITLE
Rename "cast_context" to "to_resource_options" + Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In your controller classes:
 ```ruby
 class ApplicationController < ActionController::Base
   include Garage::ControllerHelper
-  
+
   # ...
 end
 
@@ -64,6 +64,18 @@ class EmployeesController < ApplicationController
   end
 end
 ```
+
+Resources are rendered with [respond_with (responders gem)](https://github.com/heartcombo/responders).
+Additional options can be passed to respond_with by implementing `respond_with_resources_options` (index action)
+and `respond_with_resource_options` (show, update destroy actions).
+
+Available options
+* `:paginate` - (Boolean) Enable pagination when `true`. Paginates with the `per_page` and `page` params
+* `:per_page` - (Integer) value for default number of resources per page when paginating
+* `:max_per_page` - (Integer) Maximum resources per page, irrespective of requested per_page
+* `:hard_limit` - (Integer) Limit of retrievable records when paginating. Also hides total records.
+* `:distinct_by` - (Symbol) Specify a property to count by for total page count
+* `:to_resource_options` - (Hash) Options to pass as argument to `to_resource(options)`
 
 ## Create decorator for your AR models
 With not small application, you may add a presentation layer to build API responses.

--- a/lib/garage/config.rb
+++ b/lib/garage/config.rb
@@ -51,7 +51,7 @@ module Garage
     def cast_resource
       @cast_resource ||= proc { |resource, options|
         options ||= {}
-        to_resource_args = [options[:cast_context]].compact
+        to_resource_args = [options[:to_resource_options]].compact
         if resource.respond_to?(:map) && resource.respond_to?(:to_a)
           resource.map { |r| r.to_resource(*to_resource_args) }
         else

--- a/spec/dummy/app/controllers/campaigns_controller.rb
+++ b/spec/dummy/app/controllers/campaigns_controller.rb
@@ -10,6 +10,6 @@ class CampaignsController < ApiController
   end
 
   def respond_with_resource_options
-    { cast_context: { current_user: current_resource_owner } }
+    { to_resource_options: { current_user: current_resource_owner } }
   end
 end


### PR DESCRIPTION
I've updated the README to include documentation for `respond_with_resource(s)_options`. 

While thinking through the documentation, I also rethought the naming of the `cast_context` option introduced in #93. The concept of `casting` isn't mentioned elsewhere, so it is a foreign concept to most users of the library. Instead, `to_resource_options` conveys to the user the actual intent of the option: options that are passed to `to_resource`.

@cookpad/infra @eagletmt 