### PR TITLE
Avoid using automatic hash to kwargs conversion

### DIFF
--- a/lib/garage/config.rb
+++ b/lib/garage/config.rb
@@ -50,12 +50,11 @@ module Garage
 
     def cast_resource
       @cast_resource ||= proc { |resource, options|
-        options ||= {}
-        to_resource_args = [options[:to_resource_options]].compact
+        to_resource_options = options&.fetch(:to_resource_options, nil) || {}
         if resource.respond_to?(:map) && resource.respond_to?(:to_a)
-          resource.map { |r| r.to_resource(*to_resource_args) }
+          resource.map { |r| r.to_resource(**to_resource_options) }
         else
-          resource.to_resource(*to_resource_args)
+          resource.to_resource(**to_resource_options)
         end
       }
     end


### PR DESCRIPTION
When a Resource object's `to_resource` has keyword arguments, the existing implementation
relied on Ruby's automatic conversion of hash to keyword arguments. This feature is deprecated in Ruby 2.7, and will be removed in Ruby 3.0.

Here, I've refactored the call to `to_resource` to be called without the intermediate array, and just apply the double splat operator on the expected hash.

cc: @cookpad/infra 