### PR TITLE
Pass X-Request-Id to auth server

### DIFF
--- a/lib/garage/strategy/auth_server.rb
+++ b/lib/garage/strategy/auth_server.rb
@@ -89,6 +89,8 @@ module Garage
             'Resource-Owner-Id' => @request.headers['Resource-Owner-Id'],
             'Scopes' => @request.headers['Scopes'],
             'User-Agent' => USER_AGENT,
+            # ActionDispatch::Request#request_id is only available in Rails 5.0 or later.
+            'X-Request-Id' => @request.uuid,
           }.reject {|_, v| v.nil? }
         end
 


### PR DESCRIPTION
By default, Rails 3.2 and above provides a unique request id, which is either based on the X-Request-Id header in the request or a random UUID if the header is not available, through `ActionDispatch::Request#uuid`.

https://guides.rubyonrails.org/3_2_release_notes.html#action-dispatch

By passing the request id to your auth server, you can trace individual requests to the auth server.

