### PR TITLE
Kaminari 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", ">= 4.0.0"
-# FIXME: Fix garage to work with kaminari v1.
-gem "kaminari", "< 1"
+gem "kaminari-activerecord"
 gem "responders"
 
 group :development, :test do

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -3,12 +3,12 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2"
-gem "kaminari", "< 1"
+gem "kaminari-activerecord"
 gem "responders"
 gem "jquery-rails"
 
 group :development, :test do
-  gem "aws-xray", ">= 0.9.6"
+  gem "aws-xray", ">= 0.20.0"
   gem "rspec-rails"
   gem "mysql2"
   gem "pry-rails"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -3,12 +3,12 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0"
-gem "kaminari", "< 1"
+gem "kaminari-activerecord"
 gem "responders"
 gem "jquery-rails"
 
 group :development, :test do
-  gem "aws-xray", ">= 0.9.6"
+  gem "aws-xray", ">= 0.20.0"
   gem "rspec-rails"
   gem "mysql2"
   gem "pry-rails"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -3,12 +3,12 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.1"
-gem "kaminari", "< 1"
+gem "kaminari-activerecord"
 gem "responders"
 gem "jquery-rails"
 
 group :development, :test do
-  gem "aws-xray", ">= 0.9.6"
+  gem "aws-xray", ">= 0.20.0"
   gem "rspec-rails"
   gem "mysql2"
   gem "pry-rails"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -3,12 +3,12 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2"
-gem "kaminari", "< 1"
+gem "kaminari-activerecord"
 gem "responders"
 gem "jquery-rails"
 
 group :development, :test do
-  gem "aws-xray", ">= 0.9.6"
+  gem "aws-xray", ">= 0.20.0"
   gem "rspec-rails"
   gem "mysql2"
   gem "pry-rails"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.0"
-gem "kaminari", "< 1"
+gem "kaminari"
 gem "responders"
 gem "jquery-rails"
 

--- a/lib/garage/paginating_responder.rb
+++ b/lib/garage/paginating_responder.rb
@@ -90,7 +90,7 @@ module Garage
         links[:next] = rs.current_page + 1
       end
 
-      unless rs.last_page? || hide_total?
+      unless rs.last_page? || hide_total? || rs.total_pages.zero?
         links[:last] = rs.total_pages
       end
     end


### PR DESCRIPTION
Updates pagination to be compatible with Kaminari 1.x

## How

The only compatibility I noticed in the tests was dealing with an empty result set. Kaminari's behaviour has changed slightly such that `last_page?` returns false when there are no records in the set. This is because `total_pages` is now zero in this scenario. This PR patches up this minor difference, but otherwise runs correctly.
