### PR TITLE
console: send access token in header instead of query parameter

### DIFF
--- a/app/assets/javascripts/garage/docs/console.js.coffee
+++ b/app/assets/javascripts/garage/docs/console.js.coffee
@@ -9,14 +9,6 @@ jQuery ()->
     $.colorbox.close()
     ev.preventDefault()
 
-  buildAuthorizedUrl = (base, location, token) ->
-    url = base + location
-    if url.indexOf('?') > 0
-      url += '&'
-    else
-      url += '?'
-    url + 'access_token=' + token
-
   addNewParamField = (container) ->
     nextId = "parameter-" + $('.parameter', container).length
     copy = $('.template .parameter').clone().attr('id', nextId)
@@ -52,11 +44,11 @@ jQuery ()->
     $('#api-headers').text ''
     $('#api-response').text ''
 
-    url = buildAuthorizedUrl $('#base').val(), $('#location').val(), $('#access_token').val()
     console.log buildData($('.parameters'))
     $.ajax
       type: $('#method').val(),
-      url: url,
+      url: $('#base').val() + $('#location').val(),
+      headers: {'Authorization': 'Bearer ' + $('#access_token').val()},
       cache: false,
       data: buildData($('.parameters')),
       dataType: 'json',


### PR DESCRIPTION
We have ELBs and reverse proxies in front of our resource servers. Their access logs contain URLs of requests they receive. Because the garage console sends an access token in a query parameter, the token is exposed in those access logs.

I would like to prevent an access token from being written in our access logs by sending the token in an Authorization header instead of a query string.