### PR TITLE
Make received token string accessible if auth server does not return one

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Then configure auth server strategy:
 
 The OAuth server must response a json with following structure.
 
-- `token`(string) - OAuth access token value.
+- `token` (string, null) - OAuth access token value.
 - `token_type` (string) - OAuth access token value. i.e. `bearer` type.
 - `scope` (string) - OAuth scopes separated by spaces. i.e. `public read_user`.
 - `application_id` (integer) - OAuth application id of the access token.

--- a/lib/garage/strategy/access_token.rb
+++ b/lib/garage/strategy/access_token.rb
@@ -1,7 +1,8 @@
 module Garage
   module Strategy
     class AccessToken
-      attr_reader :scope, :token, :token_type, :raw_response
+      attr_accessor :token
+      attr_reader :scope, :token_type, :raw_response
 
       def initialize(attrs)
         @raw_response = attrs


### PR DESCRIPTION
When caching is enabled via `Garage.configuration.cache_acceess_token_validation = true`, Garage::Strategy::AuthServer caches a result of a token validation performed by an authorization server. If a response from the authorization server has a token string in the token field, that token string will end up being stored in a resource server's cache store.

We would like to avoid plain token strings being stored in our cache stores because some of those cache stores have no access control.

In our case, a token string in a response from our authorization server is always the same as the one a resource server receives from a client. So we could make a token string received from a client accessible via `Garage::Strategy::AccessToken#token` instead of a token string returned by the authorization server.

This PR changes to use a token string received from a client only when no token string is returned by an authorization server in order to change the existing behavior as little as possible.

If this change sounds reasonable, I will open another PR to add an option to use a hashed token string instead of a plain token string for a cache key so that no plain token strings are exposed in cache keys.