### PR TITLE
Fix tests not being run with the intended versions of Rails

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,15 +1,19 @@
 appraise 'rails-4.2' do
-  gem 'rails', '~> 4.2'
+  gem 'rails', '~> 4.2.0'
 end
 
 appraise 'rails-5.0' do
-  gem 'rails', '~> 5.0'
+  gem 'rails', '~> 5.0.0'
 end
 
 appraise 'rails-5.1' do
-  gem 'rails', '~> 5.1'
+  gem 'rails', '~> 5.1.0'
 end
 
 appraise 'rails-5.2' do
-  gem 'rails', '~> 5.2'
+  gem 'rails', '~> 5.2.0'
+end
+
+appraise 'rails-6.0' do
+  gem 'rails', '~> 6.0.0'
 end

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 4.2"
+gem "rails", "~> 4.2.0"
 gem "kaminari-activerecord"
 gem "responders"
 gem "jquery-rails"
@@ -29,4 +29,4 @@ group :test do
   gem "timecop"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.0"
+gem "rails", "~> 5.0.0"
 gem "kaminari-activerecord"
 gem "responders"
 gem "jquery-rails"
@@ -29,4 +29,4 @@ group :test do
   gem "timecop"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.1"
+gem "rails", "~> 5.1.0"
 gem "kaminari-activerecord"
 gem "responders"
 gem "jquery-rails"
@@ -29,4 +29,4 @@ group :test do
   gem "timecop"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.2"
+gem "rails", "~> 5.2.0"
 gem "kaminari-activerecord"
 gem "responders"
 gem "jquery-rails"
@@ -29,4 +29,4 @@ group :test do
   gem "timecop"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -2,13 +2,13 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0"
-gem "kaminari"
+gem "rails", "~> 6.0.0"
+gem "kaminari-activerecord"
 gem "responders"
 gem "jquery-rails"
 
 group :development, :test do
-  gem "aws-xray", ">= 0.9.6"
+  gem "aws-xray", ">= 0.20.0"
   gem "rspec-rails"
   gem "mysql2"
   gem "pry-rails"
@@ -29,4 +29,4 @@ group :test do
   gem "timecop"
 end
 
-gemspec :path => "../"
+gemspec path: "../"


### PR DESCRIPTION
[The latest CI build](https://travis-ci.org/github/cookpad/garage/builds/757828828) ran tests against only Rails 4.2, 5.2 and 6.1 because `gem 'rails', '~> 5.0'` allows bundler to install the highest released version of the rails gem between the range `>= 5.0` and `< 6.0`.

```
$ BUNDLE_GEMFILE=gemfiles/rails_5.0.gemfile bundle info rails
  * rails (5.2.4.4)
```