### PR TITLE
Replace render :text with :plain for Rails 5.1+

### DIFF
--- a/app/controllers/garage/docs/resources_controller.rb
+++ b/app/controllers/garage/docs/resources_controller.rb
@@ -86,7 +86,7 @@ class Garage::Docs::ResourcesController < Garage::ApplicationController
   def require_console_application
     @app = console_application
     if @app[:uid].blank? || @app[:secret].blank?
-      render(text: 'Configuration for console application is missing.', status: :forbidden)
+      render(plain: 'Configuration for console application is missing.', status: :forbidden)
     end
   end
 

--- a/spec/requests/docs_spec.rb
+++ b/spec/requests/docs_spec.rb
@@ -33,6 +33,15 @@ describe "Docs", type: :request do
   end
 
   describe "GET /docs/resources" do
+    context "without application_uid" do
+      let(:application_uid) do
+      end
+
+      it "returns 403" do
+        is_expected.to eq(403)
+      end
+    end
+
     context "with valid condition" do
       it "returns default overview page" do
         is_expected.to eq(200)


### PR DESCRIPTION
The `:text` option is removed from Rails 5.1.