### PR TITLE
Drop support for Rails 4.1

### DIFF
--- a/garage.gemspec
+++ b/garage.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", '>= 4.0.0'
+  s.add_dependency "rails", '>= 4.2.0'
   s.add_dependency "rack-accept-default", "~> 0.0.2"
   s.add_dependency "oj"
   s.add_dependency "responders"


### PR DESCRIPTION
garage no longer supports Rails 4.1 due to https://github.com/cookpad/garage/pull/104.