### PR TITLE
Don't return location from #create if URL pattern for #show is not found

### DIFF
--- a/lib/garage/restful_actions.rb
+++ b/lib/garage/restful_actions.rb
@@ -228,7 +228,12 @@ module Garage
     end
 
     def location
-      { action: :show, id: @resource.id } if @resource.try(:respond_to?, :id)
+      if @resource.try(:respond_to?, :id)
+        hash = { action: :show, id: @resource.id }
+        url_for(hash)
+        hash
+      end
+    rescue ActionController::UrlGenerationError
     end
   end
 end

--- a/spec/dummy/app/controllers/location_test_posts_controller.rb
+++ b/spec/dummy/app/controllers/location_test_posts_controller.rb
@@ -1,0 +1,3 @@
+class LocationTestPostsController < PostsController
+  self.resource_class = Post
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -26,4 +26,6 @@ Rails.application.routes.draw do
   resource :ping
 
   get :mine, to: 'public_posts#my'
+
+  resources :location_test_posts, only: :create
 end

--- a/spec/requests/create_location_spec.rb
+++ b/spec/requests/create_location_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+describe "Location response header from #create endpoint", type: :request do
+  include RestApiSpecHelper
+  include AuthenticatedContext
+
+  before do
+    params[:title] = "dummy"
+  end
+
+  let(:method) do
+    'post'
+  end
+
+  let(:scopes) do
+    "write_post"
+  end
+
+  context 'when URL pattern for #show exists' do
+    let(:path) do
+      '/posts'
+    end
+
+    it 'returns Location header for #show endpoint' do
+      subject
+      expect(response.status).to eq(201)
+      expect(response.headers['Location']).to eq(url_for(controller: 'posts', action: 'show', id: Post.last.id))
+    end
+  end
+
+  context 'when URL pattern for #show does not exist' do
+    let(:path) do
+      '/location_test_posts'
+    end
+
+    it 'returns Location header for #show endpoint' do
+      subject
+      expect(response.status).to eq(201)
+      expect(response.headers['Location']).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
At `#create` action, garage will try to create `#show` URL for Location response header, even if it's not defined, therefore it could cause ActionController::UrlGenerationError.

To eliminate the possibility of this kind of exception, I change `Garage::RestfulActions#location` so that it returns nil if no routing pattern is defined for `#show` action.