### PR TITLE
Migrate from sass-rails to sassc-rails

### DIFF
--- a/garage.gemspec
+++ b/garage.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "redcarpet", ">= 3.1.1"
   s.add_dependency "haml"
   s.add_dependency "hashie"
-  s.add_dependency "sass-rails"
+  s.add_dependency "sassc-rails"
   s.add_dependency "coffee-rails"
   s.add_dependency "http_accept_language", ">= 2.0.0"
 end

--- a/lib/garage/docs/engine.rb
+++ b/lib/garage/docs/engine.rb
@@ -1,6 +1,6 @@
 require "rails"
 require "haml"
-require "sass-rails"
+require "sassc-rails"
 require "coffee-rails"
 require "redcarpet"
 


### PR DESCRIPTION
Because none of the non-libsass versions of sass-rails support Rails 6, we must migrate from sass to sassc to support Rails 6.

We're not using Ruby Sass's any special features, so I think we can migrate without any problems.