### PR TITLE
Remove Rails 5.2 x Ruby 3.0 test from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,6 @@ jobs:
         continue-on-error: [false]
         include:
           - ruby: '3.0'
-            rails: '5.2'
-            continue-on-error: true # XXX: Temporary
-          - ruby: '3.0'
             rails: '6.0'
             continue-on-error: false
           - ruby: '3.0'


### PR DESCRIPTION
## Summary

Removed the combination of Rails 5.2 x Ruby 3.0 test from CI because Rails 5.2 doesn't support Ruby 3.0.

## Details

May be the folllowing page will help to check the compatibility between Ruby and Rails:

- https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html

https://github.com/cookpad/garage/pull/106 said the following, but I think it's wrong and it's not surprising that it doen's work since this combination is not officially supported by Rails.

> Test on Ruby 3.0 with Rails 5.2 is failing at this time, which seems actual "bug" in dummy application, so, we might need fix ;)

### Note

This will fix the current CI failures on the default branch.
