### PR TITLE
Add Rails 7 & Ruby 3.1 to environments of GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,16 +6,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7' ]
-        rails: [ '5.0', '5.1', '5.2', '6.0', '6.1' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
+        rails: [ '5.0', '5.1', '5.2', '6.0', '6.1', '7.0' ]
         continue-on-error: [false]
-        include:
+        exclude:
+          - ruby: '2.6'
+            rails: '7.0'
           - ruby: '3.0'
-            rails: '6.0'
-            continue-on-error: false
+            rails: '5.0'
           - ruby: '3.0'
-            rails: '6.1'
-            continue-on-error: false
+            rails: '5.1'
+          - ruby: '3.0'
+            rails: '5.2'
+          - ruby: '3.1'
+            rails: '5.0'
+          - ruby: '3.1'
+            rails: '5.1'
+          - ruby: '3.1'
+            rails: '5.2'
     continue-on-error: ${{ matrix.continue-on-error }}
     services:
       mysql:

--- a/README.md
+++ b/README.md
@@ -113,13 +113,15 @@ In `config/initializers/garage.rb`:
 Garage.configure {}
 
 # Optional
-Garage::TokenScope.configure do
-  register :public, desc: "accessing publicly available data" do
-    access :read, Recipe
-  end
+Rails.application.config.to_prepare do
+  Garage::TokenScope.configure do
+    register :public, desc: "accessing publicly available data" do
+      access :read, Recipe
+    end
 
-  register :read_post, desc: "reading blog post" do
-    access :read, Post
+    register :read_post, desc: "reading blog post" do
+      access :read, Post
+    end
   end
 end
 

--- a/gemfiles/Gemfile_rails_6.0.rb
+++ b/gemfiles/Gemfile_rails_6.0.rb
@@ -4,6 +4,9 @@ gem "rails", "~> 6.0.0"
 gem "kaminari-activerecord"
 gem "responders"
 gem "jquery-rails"
+# For Ruby 3.1
+gem 'psych', '~> 3.0'
+gem 'net-smtp', require: false
 
 group :development, :test do
   gem "aws-xray", ">= 0.20.0"

--- a/gemfiles/Gemfile_rails_6.1.rb
+++ b/gemfiles/Gemfile_rails_6.1.rb
@@ -4,6 +4,8 @@ gem "rails", "~> 6.1.0"
 gem "kaminari-activerecord"
 gem "responders"
 gem "jquery-rails"
+# For Ruby 3.1
+gem 'net-smtp', require: false
 
 group :development, :test do
   gem "aws-xray", ">= 0.20.0"

--- a/gemfiles/Gemfile_rails_7.0.rb
+++ b/gemfiles/Gemfile_rails_7.0.rb
@@ -1,0 +1,30 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 7.0.0"
+gem "kaminari-activerecord"
+gem "responders"
+gem "jquery-rails"
+
+group :development, :test do
+  gem "aws-xray", ">= 0.20.0"
+  gem "rspec-rails"
+  gem "mysql2"
+  gem "pry-rails"
+  gem "database_cleaner"
+  gem "factory_bot"
+  gem "factory_bot_rails"
+  gem "forgery"
+  gem "link_header"
+  gem "rspec-json_matcher"
+end
+
+group :development do
+  gem "puma"
+end
+
+group :test do
+  gem "webmock"
+  gem "timecop"
+end
+
+gemspec path: "../"

--- a/spec/dummy/config/initializers/garage.rb
+++ b/spec/dummy/config/initializers/garage.rb
@@ -15,38 +15,40 @@ end
 
 Garage.configuration.strategy = Garage::Strategy::Test
 
-Garage::TokenScope.configure do
-  register :public do
-    access :read, Post
-    access :read, CampaignResource
-    access :write, CampaignResource
-  end
+Rails.application.config.to_prepare do
+  Garage::TokenScope.configure do
+    register :public do
+      access :read, Post
+      access :read, CampaignResource
+      access :write, CampaignResource
+    end
 
-  register :read_private_post do
-    access :read, PrivatePost
-  end
+    register :read_private_post do
+      access :read, PrivatePost
+    end
 
-  register :write_post do
-    access :write, Post
-  end
+    register :write_post do
+      access :write, Post
+    end
 
-  register :read_post_body do
-    access :read, PostBody
-  end
+    register :read_post_body do
+      access :read, PostBody
+    end
 
-  register :sudo, hidden: true do
-    access :read, PrivatePost
-    access :read, PostStream
-  end
+    register :sudo, hidden: true do
+      access :read, PrivatePost
+      access :read, PostStream
+    end
 
-  register :meta do
-    access :read, Garage::Meta::RemoteService
-    access :read, Garage::Docs::Document
-  end
+    register :meta do
+      access :read, Garage::Meta::RemoteService
+      access :read, Garage::Docs::Document
+    end
 
-  namespace :foobar do
-    register :read_post do
-      access :read, NamespacedPost
+    namespace :foobar do
+      register :read_post do
+        access :read, NamespacedPost
+      end
     end
   end
 end


### PR DESCRIPTION
- Add Rails 7 to github actions
  - Since Rails 7, initializers script can't refer to `app/models/*.rb` files
    - Causes error while launching rails: `config/initializers/garage.rb:6:in block (2 levels) in <main>': uninitialized constant User (NameError)`
  - ref. https://guides.rubyonrails.org/v7.0/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots
- Add Ruby 3.1 to github actions