### PR TITLE
Avoid unexpected error at Garage::Utils#fuzzy_parse

### DIFF
--- a/lib/garage/utils.rb
+++ b/lib/garage/utils.rb
@@ -16,7 +16,7 @@ module Garage
     end
 
     def fuzzy_parse(date)
-      if date.is_a?(Numeric) || /^\d+$/ === date
+      if date.is_a?(Numeric) || /\A\d+\z/ === date
         Time.zone.at(date.to_i)
       else
         Time.zone.parse(date)


### PR DESCRIPTION
When the target value of Garage::Utils#fuzzy_parse contains newlines, it will not behave as expected.

```ruby
invalid_timestamp = "166\n7277881"

# old behavior
/^\d+$/ === invalid_timestamp # => true
date.to_i # => 166
Time.zone.at(date.to_i) # => Thu, 01 Jan 1970 09:02:46.000000000 JST +09:00
# This is unexpected behavior :(

# new behavior
/\Ad+\z/ === invalid_timestamp # => false
Time.zone.parse("166\n7277881") # => ArgumentError: argument out of range
# This is expected behavior :)
```

This PR corrects the behavior so that fuzzy_parse behaves as intended.