### PR TITLE
Replace TravisCI badge with GitHub Actions badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Garage
-[![Build Status](https://travis-ci.org/cookpad/garage.svg?branch=master)](https://travis-ci.org/cookpad/garage) [![Gem Version](https://badge.fury.io/rb/the_garage.svg)](https://badge.fury.io/rb/the_garage)
+[![Ruby](https://github.com/cookpad/garage/actions/workflows/main.yml/badge.svg)](https://github.com/cookpad/garage/actions/workflows/main.yml)
+[![Gem Version](https://badge.fury.io/rb/the_garage.svg)](https://badge.fury.io/rb/the_garage)
 
 Rails framework to add RESTful hypermedia API to your application.
 


### PR DESCRIPTION
We migrated to GitHub Actions at the following Pull Request, but found the old badges were still there.

- https://github.com/cookpad/garage/pull/106

This can be confusing to people who do not know what is going on and should be changed to something appropriate.

The workflow badge in GitHub Actions uses the value in its name section, so it is now showing "Ruby", but we might want to change this to an appropriate value (e.g. test) later.